### PR TITLE
fix(sm90): synchronize TMA multicast receivers

### DIFF
--- a/humming/include/humming/memory/g2s_pipeline.cuh
+++ b/humming/include/humming/memory/g2s_pipeline.cuh
@@ -132,6 +132,7 @@ public:
   LoaderBZP loader_bzp;
   LoaderBias loader_bias;
   uint32_t phases[SharedStorage::kNumMathMbarriers] = {0};
+  uint32_t multicast_phase_bits = 0;
 
   CUDA_INLINE
   ProducerPipeline(Ctx &ctx)
@@ -183,6 +184,9 @@ public:
           __mbarrier_init(&smem.math_mbar[thread_id], kNumMathThreads * factor);
         }
       }
+      if constexpr (kMultiCastSize > 1) {
+        if (thread_id < kNumStages) __mbarrier_init(&smem.multicast_mbar[thread_id], kMultiCastSize);
+      }
     }
   }
 
@@ -202,6 +206,10 @@ public:
     uint64_t *mbar_ptr = nullptr;
     if constexpr (kUseMBarrier) mbar_ptr = &smem.load_mbar[mbar_index];
     if (pred) {
+      if constexpr (kMultiCastSize > 1) {
+        expect_tma_load<kHasTmaMBarrier>(mbar_ptr, load_bytes.x);
+        wait_multicast_ready(stage_id);
+      }
       loader_a.template load<kShouldAdvance>(smem.stages[stage_id].a, mbar_ptr, stage_id);
       loader_b.template load<kShouldAdvance>(smem.stages[stage_id].b, mbar_ptr);
       if constexpr (kIsGroupInputScale) {
@@ -223,7 +231,9 @@ public:
     } else {
       commit_cp_async_load<kHasStageCpAsyncMBarrier>(mbar_index, pred);
     }
-    if (pred) expect_tma_load<kHasTmaMBarrier>(mbar_ptr, load_bytes.x);
+    if constexpr (kMultiCastSize == 1) {
+      if (pred) expect_tma_load<kHasTmaMBarrier>(mbar_ptr, load_bytes.x);
+    }
   }
 
   CUDA_INLINE void load_channel() {
@@ -248,6 +258,26 @@ public:
       if (ctx.load_thread_id() == 0) {
         tma_expect_tx(mbar_ptr, bytes);
       }
+    }
+  }
+
+  CUDA_INLINE void wait_multicast_ready(uint32_t stage_id) {
+    if constexpr (kMultiCastSize > 1) {
+      // The leader can write this stage in every peer CTA. Rendezvous only after
+      // each CTA has armed its local transaction barrier for the multicast.
+      if (ctx.load_thread_id() == 0) {
+        auto *mbar_ptr = &ctx.smem.multicast_mbar[stage_id];
+        if (ctx.cluster_rank() == 0) {
+          mbarrier_arrive(mbar_ptr);
+          const uint32_t phase = (multicast_phase_bits >> stage_id) & 1U;
+          mbarrier_wait(mbar_ptr, phase, "Humming multicast producer waiting for cluster peers");
+          multicast_phase_bits ^= 1U << stage_id;
+        } else {
+          void *remote_mbar_ptr = __cluster_map_shared_rank(mbar_ptr, 0);
+          mbarrier_arrive<true>(remote_mbar_ptr);
+        }
+      }
+      ctx.sync_load_threads();
     }
   }
 

--- a/humming/include/humming/utils/storage.cuh
+++ b/humming/include/humming/utils/storage.cuh
@@ -76,6 +76,12 @@
 #define IF_USE_MBARRIER(x)
 #endif
 
+#if HUMMING_USE_MBARRIER && HUMMING_MULTI_CAST_SIZE_A * HUMMING_MULTI_CAST_SIZE_B > 1
+#define IF_USE_MULTICAST_MBARRIER(x) x
+#else
+#define IF_USE_MULTICAST_MBARRIER(x)
+#endif
+
 #if HUMMING_USE_WARP_SPEC
 #define IF_USE_WARP_SPEC(x) x
 #else
@@ -206,4 +212,5 @@ public:
 
   IF_USE_MBARRIER(alignas(128) uint64_t load_mbar[kNumStages + 2];)
   IF_USE_WARP_SPEC(uint64_t math_mbar[kNumMathMbarriers];)
+  IF_USE_MULTICAST_MBARRIER(uint64_t multicast_mbar[kNumStages];)
 };

--- a/humming/utils/smem.py
+++ b/humming/utils/smem.py
@@ -81,6 +81,7 @@ def estimate_smem_size_layer(
     reduce_overlap_last_stage_only: bool = False,
     use_mbarrier: bool = False,
     use_warp_spec: bool = False,
+    multi_cast_size: int = 1,
     num_write_splits: int = 1,
     mma_accum_bits: int = 32,
 ) -> int:
@@ -157,6 +158,8 @@ def estimate_smem_size_layer(
         if reduce_overlap_last_stage_only and num_stages == 2:
             num_math_mbarriers += 1
         add(num_math_mbarriers * 8, 8)  # math_mbar
+    if use_mbarrier and multi_cast_size > 1:
+        add(num_stages * 8, 8)  # multicast_mbar
 
     return _align_up(offset, 1024)
 
@@ -181,6 +184,7 @@ def estimate_smem_size_config(
         reduce_overlap_last_stage_only=tuning_config.reduce_overlap_last_stage_only,
         use_mbarrier=bool(tuning_config.use_mbarrier),
         use_warp_spec=bool(tuning_config.use_warp_spec),
+        multi_cast_size=tuning_config.multi_cast_size_a * tuning_config.multi_cast_size_b,
         num_write_splits=tuning_config.num_write_splits,
         mma_accum_bits=16 if compute_config.use_f16_accum else 32,
     )

--- a/tests/kernels/humming/test_multicast.py
+++ b/tests/kernels/humming/test_multicast.py
@@ -1,0 +1,58 @@
+import torch
+
+import humming.testing.runner as runner_module
+from humming import dtypes
+from humming.config import ComputeConfig, GemmType, LayerConfig, MmaType
+from humming.testing import KernelTestCase, KernelTestRunner, skip_if_unsupported
+
+
+def test_tma_a_multicast_waits_for_receiver_stage(monkeypatch):
+    skip_if_unsupported(
+        a_dtype=dtypes.float8e4m3,
+        mma_type=MmaType.WGMMA.value,
+        use_tma=True,
+        use_warp_spec=True,
+        use_mbarrier=True,
+    )
+    tuning_values = {
+        "block_shape": (128, 128, 128),
+        "warp_shape": (128, 16, 128),
+        "use_stream_k": True,
+        "use_f16_accum": False,
+        "num_stages": 4,
+        "use_warp_spec": True,
+        "use_tma": True,
+        "use_mbarrier": True,
+        "multi_cast_size_a": 2,
+        "raster_group_m": 1,
+    }
+
+    def forced_configs(_layer_config, _compute_config, shape_ms):
+        return [dict(tuning_values) for _ in shape_ms]
+
+    monkeypatch.setattr(runner_module, "generate_heuristics_configs", forced_configs)
+    case = KernelTestCase(
+        name="tma-a-multicast-receiver-stage",
+        layer_config=LayerConfig(
+            shape_n=3072,
+            shape_k=4096,
+            a_dtype=dtypes.float8e4m3,
+            b_dtype=dtypes.float4e2m1,
+            c_dtype=dtypes.bfloat16,
+            bs_dtype=dtypes.float8e8m0,
+            input_scale_group_size=128,
+            weight_scale_group_size=32,
+            mma_type=MmaType.WGMMA,
+        ),
+        compute_config=ComputeConfig(gemm_type=GemmType.DENSE),
+        seed=2026,
+    )
+
+    (result,) = KernelTestRunner(case).run(shape_ms=(512,))
+    assert result.tuning_config.multi_cast_size_a == 2
+    torch.testing.assert_close(
+        result.outputs,
+        result.outputs_ref,
+        rtol=case.rtol,
+        atol=case.atol,
+    )


### PR DESCRIPTION
## Summary

SM90 kernels using one-dimensional TMA multicast (`mcA>1, mcB=1` or
`mcA=1, mcB>1`) can return corrupted or NaN outputs. This is a synchronization
race, not a large-GEMM arithmetic error: the multicast leader can issue a TMA
transfer before a receiver CTA has armed the destination stage's transaction
barrier.

On the pre-fix revision, the failing `M=512/4096` trials in a controlled H200
reproduction placed **4.4%–20.7%** of all BF16 output elements outside the
accepted tolerance, depending on shape and multicast direction. The reference
contained no NaNs; affected outputs contained as many as **1,589,896 NaNs**.

This PR makes every destination CTA arm its local transaction barrier first,
then uses a per-stage rank-0 readiness gate before rank 0 can issue the
multicast. The fixed revision was validated on SM90 hardware (H100 and H200)
and passed the matching forced configurations, including **322/322** author-run
H200 tensor comparisons.

This PR changes no heuristic, scheduler, MMA, datatype, or numerical tolerance.
For non-multicast kernels, the existing stage-load ordering is preserved and no
readiness barrier storage or rank-0 readiness gate is emitted.

## Impact and controlled reproduction

### How large M exposed the multicast race

Larger workloads caused the generic SM90 heuristic to select
`multi_cast_size_a=2`. In the same nine-case matrix, all four failures selected
`mcA=2`, while all five `mcA=1` cases stayed within `rtol=0.01, atol=0.05`. The
table records one pre-fix natural-heuristic run; exact corruption rates vary
with scheduling.

| Natural H100 case selecting`mcA=2` |      Elements outside tolerance |
| ------------------------------------ | ------------------------------: |
| group-128 W4A8,`M=512`             |     116,474 / 1,572,864 (7.40%) |
| group-128 W4A8,`M=4096`            | 1,959,052 / 12,582,912 (15.57%) |
| token-wise W4A8,`M=4096`           |    2,169 / 12,582,912 (0.0172%) |
| BF16 W4A16,`M=4096`                |    7,612 / 12,582,912 (0.0605%) |

The smaller percentages were not harmless low-bit drift: the recorded greatest
absolute difference was `1.648e38` for token-wise W4A8 and `3.609375` for BF16
W4A16. Large `M` selected or more frequently exposed the faulty multicast path;
it was not the arithmetic cause.

### Controlled H200 negative control

The H200 experiment removed heuristic selection and kernel geometry as
variables:

| Item | Controlled value |
|---|---|
| Before/after variable | clean pre-fix main checkout vs. fixed exact PR head `5a65293` |
| Workload | group-128 W4A8, `M x 3072 x 4096`, BF16 output |
| Datatypes | FP8 E4M3 activation, MXFP4 E2M1 weight; input/weight groups 128/32 |
| Geometry | block `(128, 128, 128)`, warp `(128, 16, 128)`, four stages |
| Pipeline | WGMMA, Stream-K, warp specialization, TMA, mbarrier, `raster_group_m=1` |
| Inputs | deterministically generated by `KernelTestRunner` with seed 2026 |
| Reference | dequantized PyTorch matmul, cast to BF16 |
| Acceptance | elementwise `torch.testing.assert_close`, `rtol=0.01`, `atol=0.05` |
| Forced configurations | `mcA=2, mcB=1` and `mcA=1, mcB=2`, tested separately |
| Repetition | each pre-fix direction repeated three times on the same H200 |
| Reported mismatch rate | elements outside tolerance divided by all `M x N` outputs |

The intervening main-branch changes before this PR's base affect only
SM120/SM121 tuning, so they do not alter the H200 SM90 path used by this
comparison.

Pre-fix results were:

| Forced config |    M | Elements outside tolerance, 3 trials |         Rate |          Output NaNs |   Result |
| ------------- | ---: | -----------------------------------: | -----------: | -------------------: | -------: |
| `mcA=2`     |  512 |         120,561–177,492 / 1,572,864 |  7.7%–11.3% |       17,152–36,864 | 3/3 FAIL |
| `mcA=2`     | 4096 |    2,477,930–2,604,981 / 12,582,912 | 19.7%–20.7% | 1,462,992–1,589,896 | 3/3 FAIL |
| `mcB=2`     |  512 |           68,632–82,656 / 1,572,864 |   4.4%–5.3% |                 2–3 | 3/3 FAIL |
| `mcB=2`     | 4096 |    2,143,894–2,367,326 / 12,582,912 | 17.0%–18.8% |                9–12 | 3/3 FAIL |

The `M=64` controls passed in all three A- and B-multicast trials. Every failing
reference contained zero NaNs. The mismatch count changed between trials,
which is expected for a scheduling race.

For A multicast, `blockIdx.x % 2` maps even N tiles to the rank-0 leader and odd
N tiles to the rank-1 receiver. Across all six failing H200 A-multicast checks,
the even/rank-0 tiles had **zero mismatches**; every mismatch was in an
odd/rank-1 receiver tile.

The fixed revision passed one run of each of the six corresponding
direction-by-M combinations: the four failing cases above plus the two `M=64`
controls. Here and below, PASS means that no checked element exceeded
`rtol=0.01, atol=0.05`; it does not claim bitwise equality. Maximum absolute and
relative errors were not retained for passing runs.

## How the cause was isolated

| Experiment                                                                        | Result                                                                | Conclusion                                                                           |
| --------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| Keep seed, geometry, pipeline, and WGMMA fixed; change only`mcA=1` to `mcA=2` | `mcA=1` stayed within tolerance; `mcA=2` failed at `M=512/4096` | Multicast, not GEMM geometry or accumulation length, is the trigger.                 |
| Leave only A on the TMA path                                                      | Same receiver-only corruption                                         | B, scales, zero points, bias, and the output store are not required to reproduce it. |
| Count mismatches by 128-column N tile                                             | Rank 0: 0; rank 1: all mismatches                                     | Corruption follows cluster receiver rank, not a K slice or WGMMA tile.               |
| Move local`expect_tx` before the loader                                         | Still failed                                                          | Correct ordering inside one CTA does not order independently scheduled CTAs.         |
| Delay consumer release to the final WGMMA use                                     | Still failed                                                          | Early stage reuse is not the primary defect.                                         |
| Use remote transaction accounting or a cluster-scope async proxy fence            | Still failed                                                          | Accounting and proxy visibility do not establish receiver producer readiness.        |
| Add a per-stage receiver-ready cluster mbarrier                                   | Passed                                                                | The missing edge is the producer-to-producer handoff before multicast issue.         |

This table summarizes author-run investigation experiments. Their one-off
diagnostic scripts and raw logs are locally archived but are not included in
this PR; the reviewer-reproducible regression added by the PR is listed under
Correctness validation.

## Root cause

TMA multicast writes the same CTA-relative shared-memory destination in every
selected CTA and delivers completion to the corresponding local transaction
barrier in each CTA. A receiver does not issue the TMA instruction, but the
stage's local transaction barrier is still part of that completion protocol.
This follows the [PTX `cp.async.bulk.tensor` specification](https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async-bulk-tensor)
and CUDA's [Distributed Shared Memory model](https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/writing-cuda-kernels.html#distributed-shared-memory).

The existing barriers protected different transitions:

| Barrier                         | What it guarantees                                                                                    |
| ------------------------------- | ----------------------------------------------------------------------------------------------------- |
| `math_mbar[stage]`            | Consumers finished the old stage, so its storage may be recycled.                                     |
| Stage-local transaction barrier | A successful consumer wait confirms that all expected asynchronous-load bytes for this CTA completed. |

Completion of `math_mbar` does not mean that every receiver's producer has
armed the stage's local transaction barrier for the next phase. Before this PR,
the leader and receiver load warps could resume independently after stage
release, with no per-phase
cluster ordering between receiver setup and leader issue:

```text
Old: receiver expect_tx ── unordered with ── leader multicast/complete_tx
New: every CTA expect_tx → signal rank-0 readiness gate → leader multicast
```

The old rank-0 order was not correct either: rank 0 could issue multicast before
its own local `expect_tx`. The visible corruption happened on receivers because
their producer warps could be delayed independently, but the fix deliberately
changes the multicast path for rank 0 and every receiver CTA.

## Fix

For each multicast stage phase:

1. Every destination CTA arms the stage's local transaction barrier with the
   expected byte count.
2. Rank 0 arrives locally at the stage readiness barrier; receivers arrive
   remotely at rank 0's copy.
3. Rank 0 waits for all destination CTA arrivals.
4. Only then may rank 0 issue multicast stage traffic.
5. Each CTA's consumer waits for TMA completion on its existing local
   transaction barrier.

The patch changes four files:

| File                                                | Change                                                                                                                                                                      |
| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `humming/include/humming/memory/g2s_pipeline.cuh` | Move multicast`expect_tx` before stage loads; initialize and reuse a per-stage readiness mbarrier; hold rank-0 multicast issue until every destination reports readiness. |
| `humming/include/humming/utils/storage.cuh`       | Add one raw 8-byte readiness mbarrier per stage only when mbarrier and multicast are both enabled.                                                                          |
| `humming/utils/smem.py`                           | Account for the same conditional storage and alignment in the Python estimator.                                                                                             |
| `tests/kernels/humming/test_multicast.py`         | Force the previously failing`M=512`, two-way TMA-A configuration and explicitly compare the output to the reference.                                                      |

The non-multicast `kMultiCastSize == 1` path keeps its former
`loads -> commit -> expect_tx` order. It does not allocate `multicast_mbar` and
does not execute the new rank-0 readiness gate.

## Correctness validation

Primary environments:

| GPU                               | Compute capability | Software                                                                        | Compiler | Fixed source |
| --------------------------------- | -----------------: | ------------------------------------------------------------------------------- | -------- | ------------ |
| NVIDIA H100 80GB HBM3             |                9.0 | PyTorch 2.10.0+cu128, CUDA 12.8                                                 | NVRTC    | `5a65293`  |
| NVIDIA H200, 132 SMs, 143,771 MiB |                9.0 | Python 3.12.3, PyTorch 2.10.0+cu128, CUDA 12.8, Triton 3.6.0; driver 580.126.09 | NVRTC    | `5a65293`  |

A separate H200 compiler leg used PyTorch 2.13.0+cu130 and CUDA 13 NVCC. All
H100 rows below and every comparison counted in the H200 322 total used the
reference and tolerance described above and an outer assertion that failed the
process on a mismatch.

| Coverage on exact PR head                                        |     H100 |                               H200 |
| ---------------------------------------------------------------- | -------: | ---------------------------------: |
| In-tree forced A-multicast regression, separate processes        | 5/5 PASS |                           5/5 PASS |
| Six group-32 issue shapes with natural heuristic; all selected `mcA=2` | 6/6 PASS |                           6/6 PASS |
| Three workloads x`M={64,512,4096}` with natural heuristic      | 9/9 PASS |                           9/9 PASS |
| Forced A and B multicast, each at`M={64,512,4096}`             | 6/6 PASS |                           6/6 PASS |
| Targeted Compute Sanitizer memcheck                              |       — | PASS, 0 errors (included in total) |
| **H200 total, including the H200 rows above and memcheck** |       — |             **322/322 PASS** |

The Python shared-memory estimate matched C++ `sizeof(SharedStorage)` for every
compiled validation kernel.

The controlled pre-fix negative control and the in-tree regression use
group-128 because that configuration reproduced the race reliably. The fixed
exact-head natural-heuristic matrix additionally covers all six group-32 issue
shapes with `mcA=2`.

<details>
<summary>H200 322-comparison breakdown</summary>

The total counts individual tensor comparisons and repeated process runs; it is
not 322 unique shapes.

| Coverage                                                                              |   Comparisons |
| ------------------------------------------------------------------------------------- | ------------: |
| Natural heuristic: 6 issue shapes + 9 non-target cases                                |            15 |
| Forced A/B directions at`M={64,512,4096}`                                           |             6 |
| Targeted process runs: smoke, 5 standard, 20 fresh, 20 concurrent, 1 memcheck         |            47 |
| NVRTC boundary values: 22 selected M values per direction spanning 1–8192            |            44 |
| NVRTC geometry: 3 stage counts x 2 M values (`512/4096`) x 2 directions             |            12 |
| NVRTC geometry: 3 block-M values x 2 M values (`512/4096`) x 2 directions           |            12 |
| NVRTC geometry: 5 K values at`M=512` x 2 directions                                 |            10 |
| NVRTC geometry: 6 N values at`M=512` x 2 directions                                 |            12 |
| NVRTC seed stress: 50 seeds per direction at`M=512`, 10 per direction at `M=4096` |           120 |
| CUDA 13 NVCC: the same 22 M boundary values per direction                             |            44 |
| **Total**                                                                       | **322** |

The exact issue shapes were `(512,3072,4096)`, `(4096,3072,4096)`,
`(8192,3072,4096)`, `(512,14336,4096)`, `(4096,14336,4096)`, and
`(4096,4096,7168)`.

Outside the 322 total, two adjacent MXFP4 dense tests and one group-32
accumulation test also passed with an empty numerical-error log.

</details>

The only reviewer-reproducible numerical check for this bug included in the PR
is:

```bash
HUMMING_COMPILER=nvrtc python -m pytest -q tests/kernels/humming/test_multicast.py
```

The broader H100/H200 matrix used locally archived author-run validation
scripts and artifacts; they are not part of this PR.

## Performance

To isolate synchronization cost, performance was measured on H200 using a
clean pre-fix main-branch checkout and the same checkout with only this patch
applied. The benchmark driver was `benchmarks/bench_humming.py`. At line 150,
it calls `triton.testing.do_bench(run, warmup=100, rep=1000)`, using a 100 ms
warmup and a 1,000 ms measurement window. Each reported value is the median of
three complete benchmark invocations. Correctness was separately rerun on the
exact PR head; intervening base changes only affect SM120/SM121 tuning.

| GPU  | Affected group-128 case | Pre-fix median (ms) | Fixed median (ms) |  Delta |
| ---- | ----------------------: | ------------------: | ----------------: | -----: |
| H200 |               `M=512` |            0.625885 |          0.624745 | -0.18% |
| H200 |              `M=4096` |            4.705326 |          4.702641 | -0.06% |

Across the full six-case H200 non-target matrix, the largest positive median
delta was +0.92%.

## Scope and review focus

- A and B multicast are supported and validated as separate configurations:
  `mcA=2, mcB=1` and `mcA=1, mcB=2`. Simultaneous A-and-B multicast is not a
  supported scheduler configuration, is not generated by current heuristics,
  and was not tested. `check_config()` does not currently reject it explicitly.
- The in-tree regression forces A multicast. B multicast is covered by the
  external H100/H200 validation matrix.
- H100 and H200 are both SM90. This PR makes no SM100/SM103 hardware-validation
  claim.
- For every active stage phase, each CTA must arrive exactly once before rank 0
  completes the readiness wait and advances that stage's phase bit.
- The storage review point is that readiness mbarriers and estimator bytes exist
  only for multicast+mbarrier kernels.
- Ruff check/format and `git diff --check` passed.
