### PR TITLE
Tune SM90 small-M FP4 schedules

### DIFF
--- a/humming/tune/sm90.py
+++ b/humming/tune/sm90.py
@@ -12,6 +12,7 @@ class Sm90Heuristics(DeviceHeuristics):
     max_smem_size: int = 227 * 1024
     # Keep two-CTA configs at 256 threads; 512 would force a 64-register limit.
     max_indexed_threads_for_two_ctas: int = 256
+    max_indexed_threads_for_three_ctas: int = 256
     b16_allowed_dtypes: list[dtypes.DataType] = [dtypes.float16, dtypes.bfloat16]
     b8_allowed_dtypes: list[dtypes.DataType] = [
         dtypes.int8,
@@ -39,9 +40,18 @@ class Sm90Heuristics(DeviceHeuristics):
             num_stages,
             warp_shape=warp_shape,
         )
-        resource_limit = 1 + int(
-            num_threads <= cls.max_indexed_threads_for_two_ctas and smem_size * 2 <= cls.max_smem_size
-        )
+        resource_limit = 1
+        if num_threads <= cls.max_indexed_threads_for_two_ctas and smem_size * 2 <= cls.max_smem_size:
+            resource_limit = 2
+        # The measured A16/B4 M8 kernels tolerate the 85-register 3-CTA bound.
+        if (
+            layer_config.a_dtype.num_bits == 16
+            and layer_config.b_dtype.num_bits == 4
+            and block_shape[0] == 8
+            and num_threads <= cls.max_indexed_threads_for_three_ctas
+            and smem_size * 3 <= cls.max_smem_size
+        ):
+            resource_limit = 3
         grid_limit = math.ceil(num_output_tiles / num_sms)
         return max(1, min(resource_limit, grid_limit))
 
@@ -100,6 +110,41 @@ class Sm90Heuristics(DeviceHeuristics):
                 warp_shape = smaller_warp_shape
                 num_ctas_per_sm = smaller_num_ctas
 
+        if (
+            layer_config.a_dtype.num_bits == 16
+            and layer_config.b_dtype.num_bits == 4
+            and block_shape[1] >= 256
+            and block_shape[2] == 64
+        ):
+            candidate_block_shape = (
+                block_shape[0],
+                block_shape[1] // 2,
+                block_shape[2] * 2,
+            )
+            candidate_warp_shape = warp_shape
+            candidate_legal = (
+                layer_config.shape_n % candidate_block_shape[1] == 0
+                and layer_config.shape_k % candidate_block_shape[2] == 0
+            )
+            if candidate_legal:
+                candidate_tiles = num_output_tiles * 2
+                candidate_ctas = cls._estimate_indexed_ctas_per_sm(
+                    layer_config,
+                    candidate_block_shape,
+                    candidate_warp_shape,
+                    num_stages,
+                    candidate_tiles,
+                    num_sms,
+                )
+                current_waves = math.ceil(num_output_tiles / (num_sms * num_ctas_per_sm))
+                candidate_waves = math.ceil(candidate_tiles / (num_sms * candidate_ctas))
+                # Trade a wider K tile for more N tiles only within the same grid wave.
+                if candidate_ctas > num_ctas_per_sm and candidate_waves <= current_waves:
+                    block_shape = candidate_block_shape
+                    warp_shape = candidate_warp_shape
+                    num_ctas_per_sm = candidate_ctas
+                    num_output_tiles = candidate_tiles
+
         # Avoid Stream-K locks once direct output tiles fill an SM wave.
         return config | {
             "block_shape": block_shape,
@@ -130,8 +175,9 @@ class Sm90Heuristics(DeviceHeuristics):
         if tune_indexed_a16:
             # Bound padding when only a few routed rows land on each expert.
             tokens_per_expert = shape_m / layer_config.num_experts
+            first_threshold = 1.01 if layer_config.b_dtype.num_bits == 4 else 0.7
             moe_block_size_configs = (
-                (8, 0.7),
+                (8, first_threshold),
                 (16, 0.7),
                 (24, 0.8),
                 (32, 0.9),
@@ -182,16 +228,33 @@ class Sm90Heuristics(DeviceHeuristics):
             elif block_shape_m <= 32:
                 warp_shape_k = warp_shape_k // 2
 
-        if tune_indexed_a16:
-            while layer_config.shape_n % block_shape_n != 0:
-                block_shape_n //= 2
-                assert block_shape_n >= warp_shape_n
-            warp_shape_n = min(warp_shape_n, block_shape_n // 4)
+        min_warp_shape_n = 32 if layer_config.a_dtype.num_bits == 16 else 16
+        # Keep a complete four-warp WGMMA group while fitting output width.
+        while layer_config.shape_n % block_shape_n != 0:
+            block_shape_n //= 2
+            assert block_shape_n >= min_warp_shape_n * 4
+        warp_shape_n = min(warp_shape_n, block_shape_n // 4)
 
+        # Earlier shape fitting can reduce block K below the initial warp K.
+        warp_shape_k = min(warp_shape_k, block_shape_k)
         while layer_config.shape_k % block_shape_k != 0:
-            warp_shape_k = 512 // layer_config.a_dtype.num_bits
             block_shape_k = block_shape_k // 2
+            warp_shape_k = min(warp_shape_k, block_shape_k)
             assert block_shape_k >= warp_shape_k
+
+        dense_small_fp4 = (
+            gemm_type == GemmType.DENSE
+            and layer_config.a_dtype.num_bits == 16
+            and layer_config.b_dtype.num_bits == 4
+            and shape_m <= 128
+            and layer_config.shape_n % 128 == 0
+            and layer_config.shape_k % 64 == 0
+        )
+        if dense_small_fp4:
+            block_shape_n = 128
+            block_shape_k = 64
+            warp_shape_n = 32
+            warp_shape_k = 64
         config = {
             "block_shape": (block_shape_m, block_shape_n, block_shape_k),
             "warp_shape": (block_shape_m, warp_shape_n, warp_shape_k),
@@ -204,6 +267,8 @@ class Sm90Heuristics(DeviceHeuristics):
             config["use_warp_spec"] = True
             config["use_tma"] = True
             config["use_mbarrier"] = True
+            if dense_small_fp4:
+                config["num_ctas_per_sm"] = 2
 
             if layer_config.shape_n % (block_shape_n * 2) == 0 and shape_m / block_shape_m >= 4:
                 if gemm_type == GemmType.DENSE:
@@ -236,9 +301,17 @@ class Sm90Heuristics(DeviceHeuristics):
         if layer_config.shape_k % 256 != 0:
             block_shape_k = 128
 
+        # N32 avoids the 512-thread grouped-scale CTA when an N128 tile fits.
+        block_shape_n = 128
+        warp_shape_n = 32
+        while layer_config.shape_n % block_shape_n != 0:
+            block_shape_n //= 2
+            warp_shape_n = min(warp_shape_n, block_shape_n // 4)
+            assert warp_shape_n >= 16
+
         config = {
-            "block_shape": (block_shape_m, 128, block_shape_k),
-            "warp_shape": (block_shape_m, 16, 128),
+            "block_shape": (block_shape_m, block_shape_n, block_shape_k),
+            "warp_shape": (block_shape_m, warp_shape_n, 128),
             "use_stream_k": not use_batch_invariant,
             "use_f16_accum": use_f16_accum,
             "num_stages": 4,

--- a/tests/kernels/humming/test_mxfp4.py
+++ b/tests/kernels/humming/test_mxfp4.py
@@ -22,16 +22,18 @@ def _layer_config(
     *,
     num_experts: int = 0,
     use_fused_e8m0_scale: bool | None = None,
+    a_dtype=dtypes.float8e4m3,
+    input_scale_group_size: int = INPUT_GROUP_SIZE,
 ) -> LayerConfig:
     return LayerConfig(
         shape_n=SHAPE_N,
         shape_k=SHAPE_K,
         num_experts=num_experts,
-        a_dtype=dtypes.float8e4m3,
+        a_dtype=a_dtype,
         b_dtype=dtypes.float4e2m1,
         c_dtype=dtypes.bfloat16,
         bs_dtype=dtypes.float8e8m0,
-        input_scale_group_size=INPUT_GROUP_SIZE,
+        input_scale_group_size=input_scale_group_size,
         weight_scale_group_size=WEIGHT_GROUP_SIZE,
         mma_type=MmaType.WGMMA,
         use_fused_e8m0_scale=use_fused_e8m0_scale,
@@ -43,6 +45,8 @@ def _case(
     *,
     gemm_type: GemmType = GemmType.DENSE,
     use_fused_e8m0_scale: bool | None = None,
+    a_dtype=dtypes.float8e4m3,
+    input_scale_group_size: int = INPUT_GROUP_SIZE,
 ) -> KernelTestCase:
     is_dense = gemm_type == GemmType.DENSE
     return KernelTestCase(
@@ -50,6 +54,8 @@ def _case(
         layer_config=_layer_config(
             num_experts=0 if is_dense else NUM_EXPERTS,
             use_fused_e8m0_scale=use_fused_e8m0_scale,
+            a_dtype=a_dtype,
+            input_scale_group_size=input_scale_group_size,
         ),
         compute_config=ComputeConfig(gemm_type=gemm_type),
         top_k=1 if is_dense else 2,
@@ -58,10 +64,40 @@ def _case(
 
 
 MXFP4_CASES = (
+    (
+        False,
+        _case(
+            "mxfp4-a16-dense",
+            a_dtype=dtypes.bfloat16,
+            input_scale_group_size=0,
+        ),
+    ),
+    (
+        False,
+        _case(
+            "mxfp4-a16-indexed",
+            gemm_type=GemmType.INDEXED,
+            a_dtype=dtypes.bfloat16,
+            input_scale_group_size=0,
+        ),
+    ),
     (True, _case("mxfp4-grouped-fp8-dense-auto")),
     (False, _case("mxfp4-grouped-fp8-dense-nonfused", use_fused_e8m0_scale=False)),
     (True, _case("mxfp4-grouped-fp8-indexed-auto", gemm_type=GemmType.INDEXED)),
-    (True, _case("mxfp4-grouped-fp8-grouped-masked-auto", gemm_type=GemmType.GROUPED_MASKED)),
+    (
+        True,
+        _case(
+            "mxfp4-grouped-fp8-grouped-contiguous-auto",
+            gemm_type=GemmType.GROUPED_CONTIGUOUS,
+        ),
+    ),
+    (
+        True,
+        _case(
+            "mxfp4-grouped-fp8-grouped-masked-auto",
+            gemm_type=GemmType.GROUPED_MASKED,
+        ),
+    ),
 )
 
 
@@ -86,6 +122,10 @@ def test_mxfp4_case_coverage():
     assert {case.compute_config.gemm_type for _, case in MXFP4_CASES} == {
         GemmType.DENSE,
         GemmType.INDEXED,
+        GemmType.GROUPED_CONTIGUOUS,
         GemmType.GROUPED_MASKED,
     }
-    assert all(case.layer_config.input_scale_group_size > 0 for _, case in MXFP4_CASES)
+    assert {case.layer_config.a_dtype for _, case in MXFP4_CASES} == {
+        dtypes.bfloat16,
+        dtypes.float8e4m3,
+    }

--- a/tests/kernels/humming/test_special_paths.py
+++ b/tests/kernels/humming/test_special_paths.py
@@ -48,6 +48,30 @@ def _kernel_case(
 
 SPECIAL_WEIGHT_CASES = (
     _kernel_case(
+        required_features=(),
+        name="nvfp4-a16-dense",
+        layer_config=_layer_config(
+            a_dtype=dtypes.bfloat16,
+            b_dtype=dtypes.float4e2m1,
+            bs_dtype=dtypes.float8e4m3,
+            weight_scale_group_size=16,
+            weight_scale_2_type=WeightScale2Type.TENSOR,
+        ),
+    ),
+    _kernel_case(
+        required_features=(),
+        name="nvfp4-a16-indexed",
+        layer_config=_layer_config(
+            a_dtype=dtypes.bfloat16,
+            b_dtype=dtypes.float4e2m1,
+            bs_dtype=dtypes.float8e4m3,
+            weight_scale_group_size=16,
+            weight_scale_2_type=WeightScale2Type.TENSOR,
+            num_experts=8,
+        ),
+        gemm_type=GemmType.INDEXED,
+    ),
+    _kernel_case(
         required_features=("use_int_weight_scale",),
         name="int-weight-scale-int8",
         layer_config=_layer_config(

--- a/tests/test_sm90_heuristics.py
+++ b/tests/test_sm90_heuristics.py
@@ -1,0 +1,217 @@
+import math
+
+import pytest
+
+from humming import dtypes
+from humming.config import GemmType, LayerConfig, MmaType
+from humming.tune.sm90 import Sm90Heuristics
+
+
+@pytest.fixture(autouse=True)
+def _mock_h200_sm_count(monkeypatch):
+    monkeypatch.setattr(
+        Sm90Heuristics,
+        "get_num_sms",
+        classmethod(lambda cls: 132),
+    )
+
+
+def _layer(
+    shape_n: int,
+    shape_k: int,
+    *,
+    num_experts: int = 12,
+    a_dtype=dtypes.float8e4m3,
+    as_dtype=dtypes.float32,
+    bs_dtype=dtypes.float8e8m0,
+    input_scale_group_size: int = 128,
+    weight_scale_group_size: int = 32,
+) -> LayerConfig:
+    return LayerConfig(
+        shape_n=shape_n,
+        shape_k=shape_k,
+        num_experts=num_experts,
+        a_dtype=a_dtype,
+        b_dtype=dtypes.float4e2m1,
+        c_dtype=dtypes.bfloat16,
+        as_dtype=as_dtype,
+        bs_dtype=bs_dtype,
+        input_scale_group_size=input_scale_group_size,
+        weight_scale_group_size=weight_scale_group_size,
+        mma_type=MmaType.WGMMA,
+    )
+
+
+@pytest.mark.parametrize(
+    ("input_scale_group_size", "as_dtype"),
+    [(128, dtypes.float32), (32, dtypes.float8e8m0)],
+)
+def test_grouped_fp8_moe_avoids_512_thread_tiles(
+    input_scale_group_size,
+    as_dtype,
+):
+    config = Sm90Heuristics.get_config(
+        _layer(
+            6144,
+            3584,
+            input_scale_group_size=input_scale_group_size,
+            as_dtype=as_dtype,
+        ),
+        shape_m=64,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    assert config["warp_shape"][1] == 32
+    block_volume = math.prod(config["block_shape"])
+    warp_volume = math.prod(config["warp_shape"])
+    num_threads = block_volume // warp_volume * 32
+    assert num_threads <= 256
+
+
+def test_grouped_fp8_uses_legal_n_tile_for_non_128_multiple():
+    config = Sm90Heuristics.get_config(
+        _layer(2880, 2880),
+        shape_m=16,
+        gemm_type=GemmType.DENSE,
+    )
+
+    assert config["block_shape"][1] == 64
+    assert config["warp_shape"][1] == 16
+
+
+def test_dense_a16_uses_legal_n_tile_for_non_256_multiple():
+    config = Sm90Heuristics.get_config(
+        _layer(
+            5760,
+            2880,
+            a_dtype=dtypes.bfloat16,
+            as_dtype=None,
+            input_scale_group_size=0,
+        ),
+        shape_m=16,
+        gemm_type=GemmType.DENSE,
+    )
+
+    assert config["block_shape"][1] == 128
+    assert config["warp_shape"][1] == 32
+
+
+def test_dense_a16_requires_padding_when_n_has_no_wgmma_tile():
+    unpadded = _layer(
+        2880,
+        2880,
+        a_dtype=dtypes.bfloat16,
+        as_dtype=None,
+        input_scale_group_size=0,
+    )
+    padded = _layer(
+        3072,
+        3072,
+        a_dtype=dtypes.bfloat16,
+        as_dtype=None,
+        input_scale_group_size=0,
+    )
+
+    with pytest.raises(AssertionError):
+        Sm90Heuristics.get_config(
+            unpadded,
+            shape_m=16,
+            gemm_type=GemmType.DENSE,
+        )
+
+    config = Sm90Heuristics.get_config(
+        padded,
+        shape_m=16,
+        gemm_type=GemmType.DENSE,
+    )
+    assert config["block_shape"][1:] == (128, 64)
+    assert config["warp_shape"][1:] == (32, 64)
+
+
+def test_short_k_does_not_leave_warp_k_larger_than_block_k():
+    config = Sm90Heuristics.get_config(
+        LayerConfig(
+            shape_n=128,
+            shape_k=64,
+            a_dtype=dtypes.int8,
+            b_dtype=dtypes.uint7,
+            c_dtype=dtypes.bfloat16,
+            bs_dtype=dtypes.bfloat16,
+            mma_type=MmaType.WGMMA,
+        ),
+        shape_m=64,
+        gemm_type=GemmType.DENSE,
+    )
+
+    assert config["block_shape"][2] == 64
+    assert config["warp_shape"][2] == 64
+
+
+@pytest.mark.parametrize(("routed_m", "expected_ctas"), [(4, 2), (8, 3), (256, 3)])
+def test_mxfp4_a16_indexed_preserves_warp_k_and_fits_grid(routed_m, expected_ctas):
+    config = Sm90Heuristics.get_config(
+        _layer(
+            5760,
+            2880,
+            num_experts=32,
+            a_dtype=dtypes.bfloat16,
+            as_dtype=None,
+            input_scale_group_size=0,
+        ),
+        shape_m=routed_m,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    assert config["block_shape"] == (8, 128, 64)
+    assert config["warp_shape"] == (8, 32, 64)
+    assert config["num_ctas_per_sm"] == expected_ctas
+    assert config["use_stream_k"] is False
+
+
+def test_nvfp4_a16_uses_narrow_first_wave_only():
+    layer = _layer(
+        5376,
+        2688,
+        num_experts=128,
+        a_dtype=dtypes.bfloat16,
+        as_dtype=None,
+        bs_dtype=dtypes.float8e4m3,
+        input_scale_group_size=0,
+        weight_scale_group_size=16,
+    )
+    first_wave = Sm90Heuristics.get_config(
+        layer,
+        shape_m=8,
+        gemm_type=GemmType.INDEXED,
+    )
+    next_wave = Sm90Heuristics.get_config(
+        layer,
+        shape_m=16,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    assert first_wave["block_shape"] == (8, 128, 128)
+    assert first_wave["warp_shape"] == (8, 32, 64)
+    assert first_wave["num_ctas_per_sm"] == 3
+    assert next_wave["block_shape"] == (8, 256, 128)
+    assert next_wave["warp_shape"] == (8, 64, 64)
+
+
+def test_fp4_a16_dense_uses_small_tile_only_through_m128():
+    layer = _layer(
+        5376,
+        2688,
+        num_experts=0,
+        a_dtype=dtypes.bfloat16,
+        as_dtype=None,
+        bs_dtype=dtypes.float8e4m3,
+        input_scale_group_size=0,
+        weight_scale_group_size=16,
+    )
+    small = Sm90Heuristics.get_config(layer, shape_m=128, gemm_type=GemmType.DENSE)
+    large = Sm90Heuristics.get_config(layer, shape_m=256, gemm_type=GemmType.DENSE)
+
+    assert small["block_shape"][1:] == (128, 64)
+    assert small["warp_shape"][1:] == (32, 64)
+    assert small["num_ctas_per_sm"] == 2
+    assert large["block_shape"][1:] != (128, 64)


### PR DESCRIPTION
## Summary

Tune the SM90 scheduler for the small-M FP4 paths exercised by MXFP4/NVFP4 A16 and grouped-FP8 activations.

- use a 256-thread N32 warp geometry for grouped-scale A8 when an N128 tile is legal, while keeping block K256 when it is legal
- preserve legal block/warp nesting while fitting N and K
- improve indexed A16/B4 residency with an M8 schedule, up to three resident CTAs, and a same-wave N/K rebalance
- use the existing N128/K64 TMA schedule for small dense A16/B4
- add focused heuristic and exact MXFP4/NVFP4 kernel correctness coverage

This keeps the existing weight layouts and changes only launch scheduling.

## Root cause

The grouped-scale SM90 path selected block `(M, 128, 256)` with warp `(M, 16, 128)`, producing a 512-thread CTA. On the reported Kimi projections this caused very low eligible-warp activity and a large latency cliff.

The A16/B4 paths had separate small-M issues: insufficient resident CTAs, excessive routed-row padding, stale warp K after divisibility fitting, and output grids that did not always justify wide N tiles or Stream-K.

## H200 performance

Grouped FP8 + MXFP4, E=12/top-8 balanced routing:

| Projection | M | old | new | speedup |
|---|---:|---:|---:|---:|
| W13 N6144 K3584 | 8 | 560.1 us | 66.9 us | 8.4x |
| W13 N6144 K3584 | 64 | 1853.0 us | 120.1 us | 15.4x |
| W2 N3584 K3072 | 8 | 296.9 us | 41.2 us | 7.2x |
| W2 N3584 K3072 | 64 | 963.8 us | 70.2 us | 13.7x |

The new geometry is neutral at M=1-4 and about 8x faster at M=256. A block-K128 ablation regressed the small endpoints, so this change does not copy a blanket block-K cap.

Matched BF16 FP4 expert-GEMM sweeps versus Marlin:

- MXFP4 gate/up: worst loss through M64 drops from 36% to 7.9%; Humming is 16-22% faster at M128-256.
- NVFP4 gate/up: one M4 point remains 10.1% behind; the other measured small-M points are 0.4-5.5% behind.
- NVFP4 down: M1 remains 14.2% behind; other measured points are 2.6-8.1% behind.
- Dense NVFP4 gate/up: worst measured loss drops to 6.7%.

The remaining NVFP4 down gap is dominated by E4M3 scale application rather than GEMM scheduling and is intentionally outside this draft.

## Validation

- `../.venv/bin/python -m pytest tests/test_sm90_heuristics.py -q`: 11 passed
- `chg run --gpus 1 --timeout 45m -- ... test_mxfp4.py test_special_paths.py -v`: 18 passed, 1 skipped
- `chg run --gpus 1 --timeout 45m -- ... humming/tests/kernels/humming -q`: 248 passed, 84 skipped
- Ruff checks on all four changed files: passed
- vLLM Humming MoE integration selection: 16 passed
- Qwen3-30B-A3B-MXFP4A16 GSM8K: 0.8976 accuracy, 0 invalid rate
- Qwen3-30B-A3B-NVFP4 GSM8K: 0.8878 accuracy, 0 invalid rate
- full-and-piecewise CUDA graph capture: all 51 configured sizes from 1 through 512 for both models; 128-question replay smoke completed with zero invalid outputs

## Scope and known limitations

This draft does not claim that FP16 NVFP4 is uniformly ahead of Marlin; several FP16 points remain 10-14% behind. It also does not add vLLM dispatch or DeepEP plumbing for MXFP4 + block-FP8 group128, and it does not claim NVFP4 grouped block-FP8 or MXFP8 activation support.

The longer-term proposal is to replace the ordered SM90 mutations with bounded schedule candidates, one shared legality/resource analyzer, and sparse offline tuning records. This draft stages the measured schedules and regression fixtures that proposal must preserve.

## Duplicate-work check

No open `inclusionAI/humming` PR matched SM90 A16/FP4 heuristics, H200/Marlin, or indexed A16.

This is not a duplicate of merged Humming #57: that change is already in the base and provides the general indexed-A16 foundation. This draft adds FP4-specific small-M residency/tile selection, dense FP4 scheduling, and grouped-A8 geometry. vLLM #51332 covers application-side block-FP8 dispatch and DeepEP plumbing and is not duplicated here.

## Disclosure

AI assistance was used in developing and validating this change.
