### PR TITLE
[Experimental] Add runtime-selectable E8M0 scaling for shared MXFP4 storage

### DIFF
--- a/humming/config/config.py
+++ b/humming/config/config.py
@@ -40,6 +40,12 @@ class LayerConfig(BaseHummingConfig):
     weight_scale_2_type: WeightScale2Type | None = None
     use_int_weight_scale: bool | None = None
     use_fused_e8m0_scale: bool | None = None
+    # Experimental V1: keep one fused-friendly MXFP4/E8M0 representation that
+    # can also be consumed by explicit accumulator scaling.  The explicit path
+    # performs an in-register mode-2 -> mode-3 repack and is correctness-first,
+    # not yet performance-equivalent to the native explicit layout.  The
+    # runtime execution choice is carried by ComputeConfig.fuse_e8m0_scale.
+    use_shared_e8m0_scale_storage: bool = False
     has_zero_point: bool = False
     is_fp_zero_point: bool = False
 
@@ -216,6 +222,25 @@ class LayerConfig(BaseHummingConfig):
                 and self.weight_scale_group_size > 0
             )
 
+        if self.use_shared_e8m0_scale_storage:
+            assert self.a_dtype == dtypes.float8e4m3, (
+                "shared E8M0 scale storage currently requires FP8 E4M3 activation"
+            )
+            assert self.b_dtype == dtypes.float4e2m1, (
+                "shared E8M0 scale storage currently requires MXFP4 E2M1 weight"
+            )
+            assert self.bs_dtype == dtypes.float8e8m0, "shared E8M0 scale storage requires E8M0 weight scales"
+            assert self.weight_scale_type == WeightScaleType.GROUP
+            assert self.weight_scale_group_size > 0
+            assert self.input_scale_group_size == 0, (
+                "shared E8M0 scale storage currently requires per-token input scales"
+            )
+            assert self.mma_type == MmaType.WGMMA, "shared E8M0 scale storage currently requires WGMMA"
+            assert not self.has_zero_point
+            # The canonical scale is relative to one per-expert FP32 base.  It
+            # must be present for both runtime execution paths.
+            self.weight_scale_2_type = WeightScale2Type.TENSOR
+
         if self.use_int_weight_scale is None:
             self.use_int_weight_scale = (
                 not self.use_fused_e8m0_scale
@@ -231,7 +256,7 @@ class LayerConfig(BaseHummingConfig):
             assert self.input_scale_group_size == 0, "use_int_weight_scale requires input_scale_group_size=0"
             self.bs_dtype = self.c_dtype
 
-        if self.use_int_weight_scale or self.use_fused_e8m0_scale:
+        if self.use_int_weight_scale or self.use_fused_e8m0_scale or self.use_shared_e8m0_scale_storage:
             self.weight_scale_type = WeightScaleType.GROUP
             # the extracted min-exponent factor becomes the secondary scale:
             # per-channel when channel2 is requested, per-tensor otherwise
@@ -252,6 +277,9 @@ class LayerConfig(BaseHummingConfig):
             assert self.a_dtype.num_bits == 8, "use_packed_k_layout requires 8-bit activation"
             assert self.b_dtype.num_bits % 2 == 0, "use_packed_k_layout requires even-bit weight"
             assert not self.use_fused_e8m0_scale, "packed_k_layout is incompatible with fused-e8m0"
+
+        if self.use_shared_e8m0_scale_storage:
+            assert not self.use_packed_k_layout, "shared E8M0 scale storage does not support packed-K layout"
 
         if type(self) is LayerConfig:
             self._config_str = self.to_str()
@@ -343,6 +371,9 @@ class ComputeConfig(BaseHummingConfig):
     use_f16_accum: bool = False
     use_batch_invariant: bool = False
     use_m_major_input_scale: bool = False
+    # None preserves the LayerConfig default.  A bool selects the compiled
+    # scale-application path without changing the resident weight tensors.
+    fuse_e8m0_scale: bool | None = None
     gemm_type: GemmType | None = None
 
     _cpp_extra_names: ClassVar[tuple[str, ...]] = (

--- a/humming/config/config.py
+++ b/humming/config/config.py
@@ -40,10 +40,8 @@ class LayerConfig(BaseHummingConfig):
     weight_scale_2_type: WeightScale2Type | None = None
     use_int_weight_scale: bool | None = None
     use_fused_e8m0_scale: bool | None = None
-    # Experimental V1: keep one fused-friendly MXFP4/E8M0 representation that
-    # can also be consumed by explicit accumulator scaling.  The explicit path
-    # performs an in-register mode-2 -> mode-3 repack and is correctness-first,
-    # not yet performance-equivalent to the native explicit layout.  The
+    # Keep one group-friendly MXFP4/E8M0 representation that supports either
+    # explicit accumulator scaling or fused register-side dequantization.  The
     # runtime execution choice is carried by ComputeConfig.fuse_e8m0_scale.
     use_shared_e8m0_scale_storage: bool = False
     has_zero_point: bool = False
@@ -231,7 +229,9 @@ class LayerConfig(BaseHummingConfig):
             )
             assert self.bs_dtype == dtypes.float8e8m0, "shared E8M0 scale storage requires E8M0 weight scales"
             assert self.weight_scale_type == WeightScaleType.GROUP
-            assert self.weight_scale_group_size > 0
+            assert self.weight_scale_group_size == 32, (
+                "shared E8M0 scale storage currently requires weight scale group size 32"
+            )
             assert self.input_scale_group_size == 0, (
                 "shared E8M0 scale storage currently requires per-token input scales"
             )

--- a/humming/include/humming/datatype/dequant_fused.cuh
+++ b/humming/include/humming/datatype/dequant_fused.cuh
@@ -29,6 +29,30 @@ CUDA_INLINE uint2 fused_dequant_single_for_mxfp4<Float8E4M3>(const uint32_t qb, 
 }
 
 
+template <uint32_t kStoredExpBias>
+CUDA_INLINE uint2 fused_dequant_single_for_mxfp4_e4m3(const uint32_t qb, const uint32_t stored_exp) {
+  // Keep the legacy fused path instruction shape while allowing a canonical
+  // E8M0 byte (relative exponent + 127) to share storage with the explicit
+  // path.  The bias is folded into the affine LUT constants at compile time.
+  constexpr uint32_t kMul1 = 0x08080800;
+  constexpr uint32_t kMul2 = 0x08080808;
+  constexpr uint32_t kAdd1 = (0x03020100 << 2) - 0x00000400 - kStoredExpBias * kMul1;
+  constexpr uint32_t kAdd2 = (0x07060504 << 2) - kStoredExpBias * kMul2;
+  uint32_t exp_offset_buffer1 = stored_exp * kMul1 + kAdd1;
+  uint32_t exp_offset_buffer2 = stored_exp * kMul2 + kAdd2;
+
+  uint32_t exp_offsets[2] = {
+      __byte_perm(exp_offset_buffer1, exp_offset_buffer2, qb),
+      __byte_perm(exp_offset_buffer1, exp_offset_buffer2, qb >> 16)};
+
+  uint32_t res[2] = {
+      lop3_and_or(qb << 4, 0x80808080, exp_offsets[0]),
+      lop3_and_or(qb, 0x80808080, exp_offsets[1])};
+
+  return *reinterpret_cast<uint2 *>(res);
+}
+
+
 template <>
 CUDA_INLINE uint2 fused_dequant_single_for_mxfp4<Int8>(const uint32_t qb, const uint32_t exp_offset) {
   uint32_t buffer1 = 0x03020100 << exp_offset;
@@ -51,22 +75,53 @@ CUDA_INLINE uint2 fused_dequant_single_for_mxfp4<Int8>(const uint32_t qb, const 
   return *reinterpret_cast<uint2 *>(res);
 }
 
-template <class TargetType, uint32_t kCount, bool kUseWgmma>
+CUDA_INLINE uint32_t mxfp4_fused_to_group_interleave(uint32_t qb) {
+  // Mode 2 keeps magnitudes in [0,1,2,3,4,5,6,7] order while signs are
+  // already in WGMMA order.  Mode 3 needs magnitudes in
+  // [0,4,1,5,2,6,3,7].  Transpose the two nibble rows with two PRMTs and
+  // preserve the already-correct sign bitplane.
+  constexpr uint32_t kMagnitudeMask = 0x07070707;
+  uint32_t even_magnitudes = qb & kMagnitudeMask;
+  uint32_t odd_magnitudes = (qb >> 4) & kMagnitudeMask;
+  uint32_t lower = __byte_perm(even_magnitudes, odd_magnitudes, 0x5140);
+  uint32_t upper = __byte_perm(even_magnitudes, odd_magnitudes, 0x7362);
+  return lower | (upper << 4) | (qb & 0x88888888);
+}
+
+
+template <uint32_t kCount>
+CUDA_INLINE void swap_mxfp4_wgmma_register_words(uint32_t *values) {
+  PRAGMA_UNROLL
+  for (uint32_t index = 0; index < kCount; index++) {
+    uint32_t tmp = values[index * 4 + 1];
+    values[index * 4 + 1] = values[index * 4 + 2];
+    values[index * 4 + 2] = tmp;
+  }
+}
+
+
+template <
+    class TargetType,
+    uint32_t kCount,
+    bool kUseWgmma,
+    uint32_t kStoredExpBias = 0>
 CUDA_INLINE void fused_dequant_for_mxfp4(const uint32_t *qb_ptrs, uint32_t *res_ptrs, uint32_t *scales_ptr) {
   PRAGMA_UNROLL
   for (uint32_t i = 0; i < kCount * 2; i++) {
     uint32_t exp_offset = reinterpret_cast<uint8_t *>(scales_ptr)[i];
-    uint2 res = fused_dequant_single_for_mxfp4<TargetType>(qb_ptrs[i], exp_offset);
+    uint32_t qb = qb_ptrs[i];
+    uint2 res;
+    if constexpr (std::is_same<TargetType, Float8E4M3>::value) {
+      res = fused_dequant_single_for_mxfp4_e4m3<kStoredExpBias>(qb, exp_offset);
+    } else {
+      static_assert(kStoredExpBias == 0, "rebased E8M0 storage only supports FP8 E4M3");
+      res = fused_dequant_single_for_mxfp4<TargetType>(qb, exp_offset);
+    }
     res_ptrs[i * 2] = res.x;
     res_ptrs[i * 2 + 1] = res.y;
   }
 
   if constexpr (kUseWgmma) {
-    PRAGMA_UNROLL
-    for (uint32_t i = 0; i < kCount; i++) {
-      uint32_t tmp = res_ptrs[i * 4 + 1];
-      res_ptrs[i * 4 + 1] = res_ptrs[i * 4 + 2];
-      res_ptrs[i * 4 + 2] = tmp;
-    }
+    swap_mxfp4_wgmma_register_words<kCount>(res_ptrs);
   }
 }

--- a/humming/include/humming/datatype/dequant_fused.cuh
+++ b/humming/include/humming/datatype/dequant_fused.cuh
@@ -53,6 +53,45 @@ CUDA_INLINE uint2 fused_dequant_single_for_mxfp4_e4m3(const uint32_t qb, const u
 }
 
 
+template <uint32_t kStoredExpBias>
+CUDA_INLINE void fused_dequant_group_interleaved_mxfp4_e4m3(
+    const uint32_t *qb,
+    uint32_t *res,
+    const uint32_t stored_exp0,
+    const uint32_t stored_exp1) {
+  // Group-friendly mode-3 storage interleaves two WGMMA rows in each packed
+  // FP4 word.  The low nibbles map to registers 0/2 and use scale 0, while
+  // the high nibbles map to registers 1/3 and use scale 1.  Build one LUT per
+  // row and emit the four WGMMA A-fragment registers directly.
+  constexpr uint32_t kMul1 = 0x08080800;
+  constexpr uint32_t kMul2 = 0x08080808;
+  constexpr uint32_t kAdd1 = (0x03020100 << 2) - 0x00000400 - kStoredExpBias * kMul1;
+  constexpr uint32_t kAdd2 = (0x07060504 << 2) - kStoredExpBias * kMul2;
+  uint32_t exp_buffer10 = stored_exp0 * kMul1 + kAdd1;
+  uint32_t exp_buffer20 = stored_exp0 * kMul2 + kAdd2;
+  uint32_t exp_buffer11 = stored_exp1 * kMul1 + kAdd1;
+  uint32_t exp_buffer21 = stored_exp1 * kMul2 + kAdd2;
+
+  PRAGMA_UNROLL
+  for (uint32_t index = 0; index < 2; index++) {
+    uint32_t packed = qb[index];
+    uint32_t aligned[2] = {packed << 4, packed};
+    PRAGMA_UNROLL
+    for (uint32_t half = 0; half < 2; half++) {
+      uint32_t magnitudes = (aligned[half] & 0x70707070) >> 4;
+      uint32_t even = __byte_perm(magnitudes, 0, 0x4420);
+      uint32_t odd = __byte_perm(magnitudes, 0, 0x4431);
+      uint32_t selectors = even | (odd << 4);
+      uint32_t exp = half == 0
+                         ? __byte_perm(exp_buffer10, exp_buffer20, selectors)
+                         : __byte_perm(exp_buffer11, exp_buffer21, selectors);
+      res[index * 2 + half] =
+          lop3_and_or(aligned[half], 0x80808080, exp);
+    }
+  }
+}
+
+
 template <>
 CUDA_INLINE uint2 fused_dequant_single_for_mxfp4<Int8>(const uint32_t qb, const uint32_t exp_offset) {
   uint32_t buffer1 = 0x03020100 << exp_offset;
@@ -74,20 +113,6 @@ CUDA_INLINE uint2 fused_dequant_single_for_mxfp4<Int8>(const uint32_t qb, const 
 
   return *reinterpret_cast<uint2 *>(res);
 }
-
-CUDA_INLINE uint32_t mxfp4_fused_to_group_interleave(uint32_t qb) {
-  // Mode 2 keeps magnitudes in [0,1,2,3,4,5,6,7] order while signs are
-  // already in WGMMA order.  Mode 3 needs magnitudes in
-  // [0,4,1,5,2,6,3,7].  Transpose the two nibble rows with two PRMTs and
-  // preserve the already-correct sign bitplane.
-  constexpr uint32_t kMagnitudeMask = 0x07070707;
-  uint32_t even_magnitudes = qb & kMagnitudeMask;
-  uint32_t odd_magnitudes = (qb >> 4) & kMagnitudeMask;
-  uint32_t lower = __byte_perm(even_magnitudes, odd_magnitudes, 0x5140);
-  uint32_t upper = __byte_perm(even_magnitudes, odd_magnitudes, 0x7362);
-  return lower | (upper << 4) | (qb & 0x88888888);
-}
-
 
 template <uint32_t kCount>
 CUDA_INLINE void swap_mxfp4_wgmma_register_words(uint32_t *values) {

--- a/humming/include/humming/datatype/dequant_fused.cuh
+++ b/humming/include/humming/datatype/dequant_fused.cuh
@@ -79,9 +79,11 @@ CUDA_INLINE void fused_dequant_group_interleaved_mxfp4_e4m3(
     PRAGMA_UNROLL
     for (uint32_t half = 0; half < 2; half++) {
       uint32_t magnitudes = (aligned[half] & 0x70707070) >> 4;
-      uint32_t even = __byte_perm(magnitudes, 0, 0x4420);
-      uint32_t odd = __byte_perm(magnitudes, 0, 0x4431);
-      uint32_t selectors = even | (odd << 4);
+      // Pack four byte-wide [0, 7] magnitudes into the four selector nibbles.
+      // DP4A keeps this work off the PRMT pipe used by the following LUT.
+      uint32_t selectors_low = __dp4a(magnitudes, 0x00001001u, 0u);
+      uint32_t selectors_high = __dp4a(magnitudes, 0x10010000u, 0u);
+      uint32_t selectors = selectors_low | (selectors_high << 8);
       uint32_t exp = half == 0
                          ? __byte_perm(exp_buffer10, exp_buffer20, selectors)
                          : __byte_perm(exp_buffer11, exp_buffer21, selectors);

--- a/humming/include/humming/mma/wgmma.cuh
+++ b/humming/include/humming/mma/wgmma.cuh
@@ -82,8 +82,22 @@ public:
 
     if constexpr (kUseFusedE8m0Scale) {
       uint32_t *regs_b_ptr = reinterpret_cast<uint32_t *>(regs_b[buffer_id]);
-      fused_dequant_for_mxfp4<ElementA, WarpShape::N / 16, true>(regs_qb[buffer_id], regs_b_ptr, arith.bs[buffer_id]);
+      constexpr uint32_t kStoredExpBias = Ctx::LayerConfig::kUseSharedE8m0ScaleStorage ? 127 : 0;
+      fused_dequant_for_mxfp4<
+          ElementA,
+          WarpShape::N / 16,
+          true,
+          kStoredExpBias>(
+          regs_qb[buffer_id], regs_b_ptr, arith.bs[buffer_id]);
     } else {
+      if constexpr (Ctx::LayerConfig::kUseSharedE8m0ScaleStorage) {
+        constexpr uint32_t kPackedWords = WarpShape::N / 16 * 2;
+        PRAGMA_UNROLL
+        for (uint32_t index = 0; index < kPackedWords; index++) {
+          regs_qb[buffer_id][index] =
+              mxfp4_fused_to_group_interleave(regs_qb[buffer_id][index]);
+        }
+      }
       if constexpr (ElementB::kBits == 1 && kNumWarpShapeNSplits == 2) {
         regs_qb[buffer_id][0] = regs_qb[buffer_id][0] >> (ctx.warp_id() % 2 * (ElementA::kBits / 2));
       }
@@ -103,6 +117,10 @@ public:
         dequant<ElementB, ElementA, kHasZeroPoint, kIsFpZeroPoint, kNumWarpShapeNSplits>(regs_qb[buffer_id], regs_b_ptr, i, zp_vals_ptr);
         arith.may_apply_bs_and_zp_on_b(regs_b_ptr, i, buffer_id);
       };
+      if constexpr (Ctx::LayerConfig::kUseSharedE8m0ScaleStorage) {
+        uint32_t *regs_b_ptr = reinterpret_cast<uint32_t *>(regs_b[buffer_id]);
+        swap_mxfp4_wgmma_register_words<WarpShape::N / 16>(regs_b_ptr);
+      }
     }
   };
 

--- a/humming/include/humming/mma/wgmma.cuh
+++ b/humming/include/humming/mma/wgmma.cuh
@@ -77,27 +77,37 @@ public:
   };
 
   CUDA_INLINE
+  void fused_dequant_shared_e8m0_scale(uint32_t buffer_id) {
+    static_assert(std::is_same<ElementA, Float8E4M3>::value);
+    constexpr uint32_t kNumBGroups = WarpShape::N * 4 / MmaShape::N / kPackedKFactor;
+    uint8_t *scale_bytes = reinterpret_cast<uint8_t *>(arith.bs[buffer_id]);
+    PRAGMA_UNROLL
+    for (uint32_t group = 0; group < kNumBGroups; group++) {
+      fused_dequant_group_interleaved_mxfp4_e4m3<127>(
+          regs_qb[buffer_id] + group * 2,
+          reinterpret_cast<uint32_t *>(regs_b[buffer_id][group]),
+          scale_bytes[group * 2],
+          scale_bytes[group * 2 + 1]);
+    }
+  }
+
+  CUDA_INLINE
   void transform_b(uint32_t buffer_id, uint32_t iter_id) {
     if constexpr (std::is_same<ElementA, ElementB>::value) return;
 
-    if constexpr (kUseFusedE8m0Scale) {
+    if constexpr (
+        kUseFusedE8m0Scale
+        && Ctx::LayerConfig::kUseSharedE8m0ScaleStorage) {
+      fused_dequant_shared_e8m0_scale(buffer_id);
+    } else if constexpr (kUseFusedE8m0Scale) {
       uint32_t *regs_b_ptr = reinterpret_cast<uint32_t *>(regs_b[buffer_id]);
-      constexpr uint32_t kStoredExpBias = Ctx::LayerConfig::kUseSharedE8m0ScaleStorage ? 127 : 0;
       fused_dequant_for_mxfp4<
           ElementA,
           WarpShape::N / 16,
           true,
-          kStoredExpBias>(
+          0>(
           regs_qb[buffer_id], regs_b_ptr, arith.bs[buffer_id]);
     } else {
-      if constexpr (Ctx::LayerConfig::kUseSharedE8m0ScaleStorage) {
-        constexpr uint32_t kPackedWords = WarpShape::N / 16 * 2;
-        PRAGMA_UNROLL
-        for (uint32_t index = 0; index < kPackedWords; index++) {
-          regs_qb[buffer_id][index] =
-              mxfp4_fused_to_group_interleave(regs_qb[buffer_id][index]);
-        }
-      }
       if constexpr (ElementB::kBits == 1 && kNumWarpShapeNSplits == 2) {
         regs_qb[buffer_id][0] = regs_qb[buffer_id][0] >> (ctx.warp_id() % 2 * (ElementA::kBits / 2));
       }
@@ -117,10 +127,6 @@ public:
         dequant<ElementB, ElementA, kHasZeroPoint, kIsFpZeroPoint, kNumWarpShapeNSplits>(regs_qb[buffer_id], regs_b_ptr, i, zp_vals_ptr);
         arith.may_apply_bs_and_zp_on_b(regs_b_ptr, i, buffer_id);
       };
-      if constexpr (Ctx::LayerConfig::kUseSharedE8m0ScaleStorage) {
-        uint32_t *regs_b_ptr = reinterpret_cast<uint32_t *>(regs_b[buffer_id]);
-        swap_mxfp4_wgmma_register_words<WarpShape::N / 16>(regs_b_ptr);
-      }
     }
   };
 

--- a/humming/kernel/humming.py
+++ b/humming/kernel/humming.py
@@ -110,6 +110,11 @@ class HummingKernel(KernelRuntime, LayerConfig, ComputeConfig, TuningConfig):
     def __post_init__(self):
         LayerConfig.__post_init__(self)
         ComputeConfig.__post_init__(self)
+        if self.fuse_e8m0_scale is not None:
+            requested = self.fuse_e8m0_scale
+            if not self.use_shared_e8m0_scale_storage and requested != self.use_fused_e8m0_scale:
+                raise ValueError("runtime E8M0 scale switching requires use_shared_e8m0_scale_storage=True")
+            self.use_fused_e8m0_scale = requested
         TuningConfig.__post_init__(self)
         KernelRuntime.__post_init__(self)
 

--- a/humming/schema/humming.py
+++ b/humming/schema/humming.py
@@ -21,6 +21,9 @@ class HummingWeightSchema(BaseWeightSchema):
     has_zero_point: bool = False
     is_fp_zero_point: bool = False
     hadamard_block_size: int = 0
+    # Keep one group-friendly MXFP4/E8M0 representation usable by both the
+    # explicit and fused runtime scale paths (see LayerConfig).
+    use_shared_e8m0_scale_storage: bool = False
 
     KWARGS_ALIAS: ClassVar[dict[str, list[str]]] = {
         "b_dtype": ["weight_dtype", "dtype"],

--- a/humming/transform.py
+++ b/humming/transform.py
@@ -444,11 +444,9 @@ def transform_humming_tensors(
 
     interleave_mode = 3
     use_legacy_fused_weight_layout = config.use_fused_e8m0_scale and not config.use_shared_e8m0_scale_storage
-    if (
-        use_legacy_fused_weight_layout or config.use_shared_e8m0_scale_storage
-    ) and config.a_dtype == dtypes.float8e4m3:
+    if use_legacy_fused_weight_layout and config.a_dtype == dtypes.float8e4m3:
         interleave_mode = 2
-    skip_mini_block_transpose = use_legacy_fused_weight_layout or config.use_shared_e8m0_scale_storage
+    skip_mini_block_transpose = use_legacy_fused_weight_layout
 
     weight = transform_humming_weight(
         weight=weight,

--- a/humming/transform.py
+++ b/humming/transform.py
@@ -426,7 +426,7 @@ def transform_humming_tensors(
     if config.weight_scale_2_type != WeightScale2Type.NONE:
         weight_scale_2 = tensors.get("weight_scale_2", None)
 
-    if config.use_fused_e8m0_scale:
+    if config.use_fused_e8m0_scale or config.use_shared_e8m0_scale_storage:
         assert weight_scale is not None
         weight, weight_scale, weight_scale_2 = process_fused_e8m0_scale(
             config,
@@ -435,9 +435,20 @@ def transform_humming_tensors(
             weight_scale_2=weight_scale_2,
         )
 
+    if config.use_shared_e8m0_scale_storage:
+        # process_fused_e8m0_scale stores a small relative exponent s in [1, 12]
+        # and a per-expert tensor base.  Rebiasing s into the native E8M0 range
+        # makes the same scale tensor directly consumable by the explicit path:
+        #   2^((s + 127) - 127) * scale_2 == 2^s * scale_2.
+        weight_scale = (weight_scale.view(torch.uint8) + 127).view(weight_scale.dtype)
+
     interleave_mode = 3
-    if config.use_fused_e8m0_scale and config.a_dtype == dtypes.float8e4m3:
+    use_legacy_fused_weight_layout = config.use_fused_e8m0_scale and not config.use_shared_e8m0_scale_storage
+    if (
+        use_legacy_fused_weight_layout or config.use_shared_e8m0_scale_storage
+    ) and config.a_dtype == dtypes.float8e4m3:
         interleave_mode = 2
+    skip_mini_block_transpose = use_legacy_fused_weight_layout or config.use_shared_e8m0_scale_storage
 
     weight = transform_humming_weight(
         weight=weight,
@@ -445,7 +456,7 @@ def transform_humming_tensors(
         a_dtype=config.a_dtype,
         zero_point=zero_point,
         use_wgmma=config.mma_type == MmaType.WGMMA,
-        use_fused_e8m0_scale=config.use_fused_e8m0_scale,
+        use_fused_e8m0_scale=skip_mini_block_transpose,
         packed=True,
         interleave_mode=interleave_mode,
         use_packed_k_layout=config.use_packed_k_layout,

--- a/humming/transform.py
+++ b/humming/transform.py
@@ -62,6 +62,7 @@ def prepare_layer_config(
         weight_scale_2_type=weight_scale_2_type,
         has_zero_point=weight_schema.has_zero_point,
         is_fp_zero_point=weight_schema.is_fp_zero_point,
+        use_shared_e8m0_scale_storage=weight_schema.use_shared_e8m0_scale_storage,
     )
 
 

--- a/humming/tune/__init__.py
+++ b/humming/tune/__init__.py
@@ -103,25 +103,146 @@ def get_heuristics_config(
             use_fused_e8m0_scale=fuse_e8m0_scale,
         )
     heuristics_cls = get_heuristics_class()
+
+    # Shared-storage layers with no explicit fuse_e8m0_scale request let the
+    # device heuristics choose the execution path per routed-M interval, so
+    # callers need no per-phase logic.  AUTO engages only for INDEXED MoE on
+    # shapes with measured winner bands; everything else (other gemm types,
+    # unmeasured shapes, devices without bands) keeps the previous behaviour
+    # (the LayerConfig default path).
+    auto_bands = None
+    if (
+        fuse_e8m0_scale is None
+        and layer_config.use_shared_e8m0_scale_storage
+        and gemm_type == GemmType.INDEXED
+    ):
+        band_map = getattr(heuristics_cls, "shared_e8m0_auto_fused_bands", None)
+        if band_map:
+            auto_bands = band_map.get((layer_config.shape_n, layer_config.shape_k, layer_config.num_experts))
+
     if isinstance(shape_m, int):
-        config = heuristics_cls.get_config(
-            layer_config=layer_config,
-            shape_m=shape_m,
-            use_f16_accum=use_f16_accum,
-            use_batch_invariant=use_batch_invariant,
-            gemm_type=gemm_type,
-        )
+        if auto_bands is not None:
+            layer_config, config = _shared_auto_single_config(
+                heuristics_cls,
+                layer_config,
+                shape_m=shape_m,
+                use_f16_accum=use_f16_accum,
+                use_batch_invariant=use_batch_invariant,
+                gemm_type=gemm_type,
+                fused_bands=auto_bands,
+            )
+        else:
+            config = heuristics_cls.get_config(
+                layer_config=layer_config,
+                shape_m=shape_m,
+                use_f16_accum=use_f16_accum,
+                use_batch_invariant=use_batch_invariant,
+                gemm_type=gemm_type,
+            )
         _apply_m_major_input_scale(config, use_m_major_input_scale, layer_config, gemm_type)
         _apply_raster_group_m(config, layer_config, gemm_type)
         return config
     else:
-        configs = heuristics_cls.get_configs(
-            layer_config=layer_config,
-            use_f16_accum=use_f16_accum,
-            use_batch_invariant=use_batch_invariant,
-            gemm_type=gemm_type,
-        )
+        if auto_bands is not None:
+            configs = _shared_auto_config_table(
+                heuristics_cls,
+                layer_config,
+                use_f16_accum=use_f16_accum,
+                use_batch_invariant=use_batch_invariant,
+                gemm_type=gemm_type,
+                fused_bands=auto_bands,
+            )
+        else:
+            configs = heuristics_cls.get_configs(
+                layer_config=layer_config,
+                use_f16_accum=use_f16_accum,
+                use_batch_invariant=use_batch_invariant,
+                gemm_type=gemm_type,
+            )
         for entry in configs:
             _apply_m_major_input_scale(entry[2], use_m_major_input_scale, layer_config, gemm_type)
             _apply_raster_group_m(entry[2], layer_config, gemm_type)
         return configs
+
+
+def _in_fused_bands(fused_bands, routed_m: int) -> bool:
+    return any(lo < routed_m and (hi is None or routed_m <= hi) for lo, hi in fused_bands)
+
+
+def _shared_auto_single_config(
+    heuristics_cls,
+    layer_config: LayerConfig,
+    *,
+    shape_m: int,
+    use_f16_accum: bool,
+    use_batch_invariant: bool,
+    gemm_type: GemmType,
+    fused_bands,
+):
+    """Resolve the shared-storage execution path for one routed-M value."""
+    use_fused = _in_fused_bands(fused_bands, shape_m)
+    path_layer = dataclasses.replace(layer_config, use_fused_e8m0_scale=use_fused)
+    config = heuristics_cls.get_config(
+        layer_config=path_layer,
+        shape_m=shape_m,
+        use_f16_accum=use_f16_accum,
+        use_batch_invariant=use_batch_invariant,
+        gemm_type=gemm_type,
+    )
+    # Route through ComputeConfig.fuse_e8m0_scale so per-interval kernels take
+    # the same validated override path as an explicit caller request.
+    config["fuse_e8m0_scale"] = use_fused
+    return path_layer, config
+
+
+def _shared_auto_config_table(
+    heuristics_cls,
+    layer_config: LayerConfig,
+    *,
+    use_f16_accum: bool,
+    use_batch_invariant: bool,
+    gemm_type: GemmType,
+    fused_bands,
+):
+    """Merge the explicit/fused interval tables into one path-annotated table.
+
+    Table entries are ``(lo_exclusive, hi_inclusive, config)``.  Every merged
+    sub-interval picks the path from the measured winner bands; the choice is
+    recorded as ``fuse_e8m0_scale`` in the config so each interval compiles
+    its own kernel variant through the standard ComputeConfig override.
+    """
+    tables = {}
+    for fused in (False, True):
+        tables[fused] = heuristics_cls.get_configs(
+            layer_config=dataclasses.replace(layer_config, use_fused_e8m0_scale=fused),
+            use_f16_accum=use_f16_accum,
+            use_batch_invariant=use_batch_invariant,
+            gemm_type=gemm_type,
+        )
+
+    def lookup(table, routed_m):
+        for lo, hi, config in table:
+            if lo < routed_m <= hi:
+                return config
+        raise RuntimeError(f"no heuristic interval contains routed_m={routed_m}")
+
+    breakpoints = {bound for table in tables.values() for lo, hi, _ in table for bound in (lo, hi)}
+    max_bound = max(breakpoints)
+    # Winner-band edges must become interval boundaries too, or the path
+    # decision would be quantized to the underlying tables' sampling grid.
+    for lo, hi in fused_bands:
+        for bound in (lo, hi):
+            if bound is not None and 0 < bound < max_bound:
+                breakpoints.add(bound)
+    breakpoints = sorted(breakpoints)
+    merged = []
+    for lo, hi in zip(breakpoints, breakpoints[1:], strict=False):
+        probe_m = lo + 1
+        use_fused = _in_fused_bands(fused_bands, probe_m)
+        config = dict(lookup(tables[use_fused], probe_m))
+        config["fuse_e8m0_scale"] = use_fused
+        if merged and merged[-1][1] == lo and merged[-1][2] == config:
+            merged[-1] = (merged[-1][0], hi, merged[-1][2])
+        else:
+            merged.append((lo, hi, config))
+    return merged

--- a/humming/tune/__init__.py
+++ b/humming/tune/__init__.py
@@ -1,3 +1,4 @@
+import dataclasses
 import functools
 
 import torch
@@ -84,6 +85,7 @@ def get_heuristics_config(
     use_f16_accum: bool = False,
     use_batch_invariant: bool = False,
     use_m_major_input_scale: bool = False,
+    fuse_e8m0_scale: bool | None = None,
     gemm_type: str | GemmType = "dense",
 ):
     if isinstance(gemm_type, str):
@@ -91,6 +93,15 @@ def get_heuristics_config(
 
     if isinstance(layer_config, dict):
         layer_config = LayerConfig(**layer_config)
+    if fuse_e8m0_scale is not None:
+        if not layer_config.use_shared_e8m0_scale_storage and (
+            fuse_e8m0_scale != layer_config.use_fused_e8m0_scale
+        ):
+            raise ValueError("runtime E8M0 scale switching requires use_shared_e8m0_scale_storage=True")
+        layer_config = dataclasses.replace(
+            layer_config,
+            use_fused_e8m0_scale=fuse_e8m0_scale,
+        )
     heuristics_cls = get_heuristics_class()
     if isinstance(shape_m, int):
         config = heuristics_cls.get_config(

--- a/humming/tune/sm90_h20.py
+++ b/humming/tune/sm90_h20.py
@@ -14,6 +14,23 @@ class Sm90H20Heuristics(DeviceHeuristics):
     b8_allowed_dtypes: list[dtypes.DataType] = [dtypes.int8, dtypes.float8e4m3, dtypes.float8e5m2]
     b4_allowed_dtypes: list[dtypes.DataType] = []
     sm_version: int = 90
+    # Shared-storage layers may leave ComputeConfig.fuse_e8m0_scale unset; the
+    # heuristics then pick the execution path per routed-M interval from the
+    # measured winner bands below.  Keys are (shape_n, shape_k, num_experts)
+    # — interval-table boundaries depend on all three; values are routed-M
+    # bands (lo_exclusive, hi_inclusive or None for open-ended) where the
+    # fused path wins, with explicit accumulator scaling used elsewhere.
+    # AUTO engages only for these measured shapes and only for INDEXED MoE
+    # (K3 TP8 full four-arm integer-M sweeps, 2026-08-19); everything else
+    # keeps the previous behaviour of following the LayerConfig default path.
+    shared_e8m0_auto_fused_bands: dict[tuple[int, int, int], tuple] = {
+        # K3 W13: fused pocket where the explicit schedule collapses (up to
+        # 1.6x slower) right after the BM16->32 boundary, then fused again
+        # from the BM48 boundary onwards.
+        (768, 3584, 896): ((11456, 14336), (25728, None)),
+        # K3 W2: single flip at the BM48 boundary.
+        (3584, 384, 896): ((25728, None),),
+    }
 
     @classmethod
     def _apply_shared_e8m0_overrides(
@@ -31,6 +48,29 @@ class Sm90H20Heuristics(DeviceHeuristics):
             config["use_stream_k"] = False
         elif layer_config.shape_k <= 512:
             config["num_sms"] = max(3072, config["num_sms"])
+            if layer_config.shape_k >= 384:
+                # Measured on K3 TP8 W2 (N=3584, K=384) dense integer-M sweep
+                # (2026-08-19): BN128/WN32/stage3/CTA4/TMA + grid>=3072 beats
+                # the native-derived schedule on all 6584 BM>=48 points,
+                # lifting the shared-fused/native-fused geomean from 0.942 to
+                # 0.981.  The extra resident warpgroups hide the shared
+                # decoder's selector-pack ALU chain, which paired NCU/SASS
+                # work showed is the residual cost.  DSV4-Flash W2 (N=4096,
+                # K=256) regresses 6-8% under this schedule, hence the K
+                # floor: only the measured shape family opts in.
+                block_k = config["block_shape"][2]
+                config["block_shape"] = (block_m, 128, block_k)
+                config["warp_shape"] = (block_m, 32, block_k)
+                config["num_stages"] = 3
+                config["num_ctas_per_sm"] = 4
+                config["use_stream_k"] = False
+                for key in tuple(config):
+                    if key.startswith("use_tma") or key == "use_mbarrier":
+                        config.pop(key)
+                config["use_tma"] = True
+                config["use_mbarrier"] = True
+                config["use_tma_a"] = False
+                config["use_tma_c"] = False
 
     @classmethod
     def _get_small_m_dense_override(

--- a/humming/tune/sm90_h20.py
+++ b/humming/tune/sm90_h20.py
@@ -16,6 +16,23 @@ class Sm90H20Heuristics(DeviceHeuristics):
     sm_version: int = 90
 
     @classmethod
+    def _apply_shared_e8m0_overrides(
+        cls,
+        layer_config: LayerConfig,
+        config: dict,
+    ) -> None:
+        """Apply measured large-M schedules for group-friendly shared storage."""
+        if not layer_config.use_shared_e8m0_scale_storage:
+            return
+        block_m = config["block_shape"][0]
+        if block_m < 48:
+            return
+        if layer_config.shape_k > 1024:
+            config["use_stream_k"] = False
+        elif layer_config.shape_k <= 512:
+            config["num_sms"] = max(3072, config["num_sms"])
+
+    @classmethod
     def _get_small_m_dense_override(
         cls,
         layer_config: LayerConfig,
@@ -505,5 +522,8 @@ class Sm90H20Heuristics(DeviceHeuristics):
             config["use_warp_spec"] = False
             config["use_mbarrier"] = False
             config["use_stream_k"] = False
+
+        if not use_batch_invariant:
+            cls._apply_shared_e8m0_overrides(layer_config, config)
 
         return config

--- a/humming/tune/sm90_h20.py
+++ b/humming/tune/sm90_h20.py
@@ -22,7 +22,7 @@ class Sm90H20Heuristics(DeviceHeuristics):
         config: dict,
     ) -> None:
         """Apply measured large-M schedules for group-friendly shared storage."""
-        if not layer_config.use_shared_e8m0_scale_storage:
+        if not layer_config.use_shared_e8m0_scale_storage or not layer_config.use_fused_e8m0_scale:
             return
         block_m = config["block_shape"][0]
         if block_m < 48:

--- a/tests/kernels/humming/test_mxfp4.py
+++ b/tests/kernels/humming/test_mxfp4.py
@@ -1,6 +1,7 @@
 """MXFP4 W4A8 coverage with grouped FP8 inputs."""
 
 import pytest
+import torch
 
 from humming import dtypes
 from humming.config import ComputeConfig, GemmType, LayerConfig, MmaType
@@ -89,3 +90,77 @@ def test_mxfp4_case_coverage():
         GemmType.GROUPED_MASKED,
     }
     assert all(case.layer_config.input_scale_group_size > 0 for _, case in MXFP4_CASES)
+
+
+def _shared_storage_case(*, fuse_e8m0_scale: bool) -> KernelTestCase:
+    return KernelTestCase(
+        name=f"mxfp4-shared-storage-{'fused' if fuse_e8m0_scale else 'explicit'}",
+        layer_config=LayerConfig(
+            shape_n=256,
+            shape_k=256,
+            num_experts=NUM_EXPERTS,
+            a_dtype=dtypes.float8e4m3,
+            b_dtype=dtypes.float4e2m1,
+            c_dtype=dtypes.bfloat16,
+            bs_dtype=dtypes.float8e8m0,
+            input_scale_group_size=0,
+            weight_scale_group_size=WEIGHT_GROUP_SIZE,
+            mma_type=MmaType.WGMMA,
+            use_shared_e8m0_scale_storage=True,
+        ),
+        compute_config=ComputeConfig(
+            gemm_type=GemmType.INDEXED,
+            fuse_e8m0_scale=fuse_e8m0_scale,
+        ),
+        top_k=2,
+        seed=2027,
+    )
+
+
+@pytest.mark.parametrize("fuse_e8m0_scale", [False, True], ids=["explicit", "fused"])
+def test_mxfp4_shared_storage_runtime_scale_mode(fuse_e8m0_scale):
+    test_case = _shared_storage_case(fuse_e8m0_scale=fuse_e8m0_scale)
+    config = test_case.layer_config
+    assert config.use_shared_e8m0_scale_storage
+    assert config.is_tensor_weight_scale_2
+    assert not config.use_packed_k_layout
+
+    skip_if_unsupported(a_dtype=config.a_dtype, mma_type=config.mma_type.value)
+    results = KernelTestRunner(test_case).run((17,))
+    assert len(results) == 1
+    torch.testing.assert_close(
+        results[0].outputs,
+        results[0].outputs_ref,
+        rtol=test_case.rtol,
+        atol=test_case.atol,
+    )
+
+
+def test_mxfp4_shared_storage_reuses_resident_tensors():
+    explicit_case = _shared_storage_case(fuse_e8m0_scale=False)
+    fused_case = _shared_storage_case(fuse_e8m0_scale=True)
+    skip_if_unsupported(
+        a_dtype=explicit_case.layer_config.a_dtype,
+        mma_type=explicit_case.layer_config.mma_type.value,
+    )
+
+    explicit_runner = KernelTestRunner(explicit_case)
+    fused_runner = KernelTestRunner(fused_case)
+    fused_runner.kernel_tensors = explicit_runner.kernel_tensors
+    fused_runner.weight_ref = explicit_runner.weight_ref
+
+    for name in ("weight", "weight_scale", "weight_scale_2"):
+        assert explicit_runner.kernel_tensors[name].data_ptr() == fused_runner.kernel_tensors[name].data_ptr()
+    stored_scale = explicit_runner.kernel_tensors["weight_scale"].view(torch.uint8)
+    assert int(stored_scale.min().item()) >= 128
+    assert int(stored_scale.max().item()) <= 139
+
+    explicit = explicit_runner.run((17,))[0]
+    fused = fused_runner.run((17,))[0]
+    for result, test_case in ((explicit, explicit_case), (fused, fused_case)):
+        torch.testing.assert_close(
+            result.outputs,
+            result.outputs_ref,
+            rtol=test_case.rtol,
+            atol=test_case.atol,
+        )

--- a/tests/kernels/humming/test_mxfp4.py
+++ b/tests/kernels/humming/test_mxfp4.py
@@ -136,6 +136,38 @@ def test_mxfp4_shared_storage_runtime_scale_mode(fuse_e8m0_scale):
     )
 
 
+def test_mxfp4_shared_storage_schema_plumbing():
+    from humming.schema.humming import HummingInputSchema, HummingWeightSchema
+    from humming.transform import prepare_layer_config
+
+    weight_schema = HummingWeightSchema(
+        b_dtype=dtypes.float4e2m1,
+        bs_dtype=dtypes.float8e8m0,
+        weight_scale_group_size=WEIGHT_GROUP_SIZE,
+        use_shared_e8m0_scale_storage=True,
+    )
+    input_schema = HummingInputSchema(
+        a_dtype=dtypes.float8e4m3,
+        input_scale_group_size=0,
+    )
+    config = prepare_layer_config(
+        shape_n=256,
+        shape_k=256,
+        weight_schema=weight_schema,
+        input_schema=input_schema,
+        num_experts=NUM_EXPERTS,
+        torch_dtype=torch.bfloat16,
+    )
+    assert config.use_shared_e8m0_scale_storage
+    # Default derivation keeps the fused-capable resident semantics.
+    assert config.use_fused_e8m0_scale
+    assert not HummingWeightSchema(
+        b_dtype=dtypes.float4e2m1,
+        bs_dtype=dtypes.float8e8m0,
+        weight_scale_group_size=WEIGHT_GROUP_SIZE,
+    ).use_shared_e8m0_scale_storage
+
+
 def test_mxfp4_shared_storage_reuses_resident_tensors():
     explicit_case = _shared_storage_case(fuse_e8m0_scale=False)
     fused_case = _shared_storage_case(fuse_e8m0_scale=True)

--- a/tests/test_sm90_h20_heuristics.py
+++ b/tests/test_sm90_h20_heuristics.py
@@ -129,3 +129,26 @@ def test_shared_e8m0_small_m_keeps_existing_schedule():
 
     assert config["block_shape"][0] == 8
     assert config["use_stream_k"]
+
+
+def test_shared_e8m0_explicit_path_keeps_native_large_m_schedule():
+    shared_explicit = Sm90H20Heuristics.get_config(
+        dataclasses.replace(
+            _shared_layer(768, 3584, num_experts=896),
+            use_fused_e8m0_scale=False,
+        ),
+        131072,
+        gemm_type=GemmType.INDEXED,
+    )
+    native_explicit = Sm90H20Heuristics.get_config(
+        dataclasses.replace(
+            _shared_layer(768, 3584, num_experts=896),
+            use_fused_e8m0_scale=False,
+            use_shared_e8m0_scale_storage=False,
+        ),
+        131072,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    assert shared_explicit == native_explicit
+    assert shared_explicit["use_stream_k"]

--- a/tests/test_sm90_h20_heuristics.py
+++ b/tests/test_sm90_h20_heuristics.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 import pytest
 
 from humming import dtypes
@@ -21,6 +23,22 @@ def _layer(shape_n: int, shape_k: int, num_experts: int = 0) -> LayerConfig:
         bs_dtype=dtypes.bfloat16,
         weight_scale_group_size=0,
         mma_type=MmaType.WGMMA,
+    )
+
+
+def _shared_layer(shape_n: int, shape_k: int, num_experts: int) -> LayerConfig:
+    return LayerConfig(
+        shape_n=shape_n,
+        shape_k=shape_k,
+        num_experts=num_experts,
+        a_dtype=dtypes.float8e4m3,
+        b_dtype=dtypes.float4e2m1,
+        c_dtype=dtypes.bfloat16,
+        bs_dtype=dtypes.float8e8m0,
+        input_scale_group_size=0,
+        weight_scale_group_size=32,
+        mma_type=MmaType.WGMMA,
+        use_shared_e8m0_scale_storage=True,
     )
 
 
@@ -69,3 +87,45 @@ def test_sparse_long_k_moe_keeps_two_n_tiles_per_expert(shape_n, block_n):
 
     assert config["block_shape"] == (8, block_n, 64)
     assert config["num_stages"] == 3
+
+
+def test_shared_e8m0_large_m_long_k_disables_stream_k():
+    shared = Sm90H20Heuristics.get_config(
+        _shared_layer(768, 3584, num_experts=896),
+        131072,
+        gemm_type=GemmType.INDEXED,
+    )
+    native = Sm90H20Heuristics.get_config(
+        dataclasses.replace(
+            _shared_layer(768, 3584, num_experts=896),
+            use_shared_e8m0_scale_storage=False,
+        ),
+        131072,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    assert shared["block_shape"][0] >= 48
+    assert not shared["use_stream_k"]
+    assert native["use_stream_k"]
+
+
+def test_shared_e8m0_large_m_short_k_uses_larger_grid():
+    shared = Sm90H20Heuristics.get_config(
+        _shared_layer(3584, 384, num_experts=896),
+        131072,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    assert shared["block_shape"][0] >= 48
+    assert shared["num_sms"] >= 3072
+
+
+def test_shared_e8m0_small_m_keeps_existing_schedule():
+    config = Sm90H20Heuristics.get_config(
+        _shared_layer(768, 3584, num_experts=896),
+        2048,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    assert config["block_shape"][0] == 8
+    assert config["use_stream_k"]

--- a/tests/test_sm90_h20_heuristics.py
+++ b/tests/test_sm90_h20_heuristics.py
@@ -109,15 +109,49 @@ def test_shared_e8m0_large_m_long_k_disables_stream_k():
     assert native["use_stream_k"]
 
 
-def test_shared_e8m0_large_m_short_k_uses_larger_grid():
+def test_shared_e8m0_large_m_short_k_uses_cta4_schedule():
     shared = Sm90H20Heuristics.get_config(
         _shared_layer(3584, 384, num_experts=896),
         131072,
         gemm_type=GemmType.INDEXED,
     )
 
+    block_m = shared["block_shape"][0]
+    assert block_m >= 48
+    assert shared["block_shape"][1] == 128
+    assert shared["warp_shape"] == (block_m, 32, shared["block_shape"][2])
+    assert shared["num_stages"] == 3
+    assert shared["num_ctas_per_sm"] == 4
+    assert not shared["use_stream_k"]
+    assert shared["use_tma"]
+    assert shared["use_mbarrier"]
+    assert not shared["use_tma_a"]
+    assert not shared["use_tma_c"]
+    assert shared["num_sms"] >= 3072
+
+
+def test_shared_e8m0_very_short_k_keeps_native_schedule_with_grid_bump():
+    # DSV4-Flash W2 (K=256) regresses under the CTA4 schedule; only the grid
+    # floor applies below the measured K window.
+    shared = Sm90H20Heuristics.get_config(
+        _shared_layer(4096, 256, num_experts=256),
+        49152,
+        gemm_type=GemmType.INDEXED,
+    )
+    native = Sm90H20Heuristics.get_config(
+        dataclasses.replace(
+            _shared_layer(4096, 256, num_experts=256),
+            use_shared_e8m0_scale_storage=False,
+        ),
+        49152,
+        gemm_type=GemmType.INDEXED,
+    )
+
     assert shared["block_shape"][0] >= 48
     assert shared["num_sms"] >= 3072
+    assert shared["block_shape"] == native["block_shape"]
+    assert shared["num_stages"] == native["num_stages"]
+    assert shared["num_ctas_per_sm"] == native["num_ctas_per_sm"]
 
 
 def test_shared_e8m0_small_m_keeps_existing_schedule():
@@ -152,3 +186,112 @@ def test_shared_e8m0_explicit_path_keeps_native_large_m_schedule():
 
     assert shared_explicit == native_explicit
     assert shared_explicit["use_stream_k"]
+
+
+def _auto_single(layer, shape_m):
+    from humming.tune import _shared_auto_single_config
+
+    bands = Sm90H20Heuristics.shared_e8m0_auto_fused_bands[(layer.shape_n, layer.shape_k, layer.num_experts)]
+    _, config = _shared_auto_single_config(
+        Sm90H20Heuristics,
+        layer,
+        shape_m=shape_m,
+        use_f16_accum=False,
+        use_batch_invariant=False,
+        gemm_type=GemmType.INDEXED,
+        fused_bands=bands,
+    )
+    return config
+
+
+def test_shared_e8m0_auto_picks_explicit_for_decode_m():
+    config = _auto_single(_shared_layer(3584, 384, num_experts=896), 2048)
+
+    assert config["fuse_e8m0_scale"] is False
+    assert config["block_shape"][0] < 48
+
+
+def test_shared_e8m0_auto_picks_fused_cta4_for_large_m():
+    config = _auto_single(_shared_layer(3584, 384, num_experts=896), 131072)
+
+    assert config["fuse_e8m0_scale"] is True
+    assert config["num_ctas_per_sm"] == 4
+    assert config["num_stages"] == 3
+    assert not config["use_stream_k"]
+
+
+def _auto_table(layer):
+    from humming.tune import _shared_auto_config_table
+
+    return _shared_auto_config_table(
+        Sm90H20Heuristics,
+        layer,
+        use_f16_accum=False,
+        use_batch_invariant=False,
+        gemm_type=GemmType.INDEXED,
+        fused_bands=Sm90H20Heuristics.shared_e8m0_auto_fused_bands[
+            (layer.shape_n, layer.shape_k, layer.num_experts)
+        ],
+    )
+
+
+def _table_path(table, routed_m):
+    for lo, hi, config in table:
+        if lo < routed_m <= hi:
+            return config["fuse_e8m0_scale"]
+    raise AssertionError(routed_m)
+
+
+def test_shared_e8m0_auto_w2_table_flips_at_measured_band():
+    table = _auto_table(_shared_layer(3584, 384, num_experts=896))
+
+    for (_, prev_hi, _), (lo, _, _) in zip(table, table[1:], strict=False):
+        assert prev_hi == lo
+    assert all("fuse_e8m0_scale" in config for _, _, config in table)
+    assert _table_path(table, 2048) is False
+    assert _table_path(table, 25728) is False
+    assert _table_path(table, 25729) is True
+    assert _table_path(table, 131072) is True
+
+
+def test_shared_e8m0_auto_w13_table_has_fused_pocket():
+    table = _auto_table(_shared_layer(768, 3584, num_experts=896))
+
+    assert _table_path(table, 2048) is False
+    assert _table_path(table, 11456) is False
+    assert _table_path(table, 11457) is True
+    assert _table_path(table, 14336) is True
+    assert _table_path(table, 14337) is False
+    assert _table_path(table, 25728) is False
+    assert _table_path(table, 25729) is True
+    assert _table_path(table, 131072) is True
+
+
+def test_shared_e8m0_auto_only_engages_for_measured_shapes(monkeypatch):
+    import humming.tune as tune
+
+    monkeypatch.setattr(tune, "get_heuristics_class", lambda *a, **k: Sm90H20Heuristics)
+    tune.get_heuristics_config.cache_clear()
+    try:
+        layer = _shared_layer(3584, 384, num_experts=896)
+
+        auto = tune.get_heuristics_config(layer, 131072, gemm_type=GemmType.INDEXED)
+        assert auto["fuse_e8m0_scale"] is True
+
+        forced = tune.get_heuristics_config(layer, 131072, fuse_e8m0_scale=False, gemm_type=GemmType.INDEXED)
+        assert "fuse_e8m0_scale" not in forced
+
+        table = tune.get_heuristics_config(layer, gemm_type=GemmType.INDEXED)
+        assert all("fuse_e8m0_scale" in config for _, _, config in table)
+
+        # Unmeasured shared shape: AUTO stays off, plain table, no flags.
+        other = tune.get_heuristics_config(
+            _shared_layer(4096, 256, num_experts=256), gemm_type=GemmType.INDEXED
+        )
+        assert all("fuse_e8m0_scale" not in config for _, _, config in other)
+
+        # Unmeasured gemm type on a measured shape: AUTO stays off too.
+        dense_like = tune.get_heuristics_config(layer, gemm_type=GemmType.GROUPED_CONTIGUOUS)
+        assert all("fuse_e8m0_scale" not in config for _, _, config in dense_like)
+    finally:
+        tune.get_heuristics_config.cache_clear()


### PR DESCRIPTION
## Summary

This draft introduces an experimental runtime-selectable E8M0 scale path for
Humming MXFP4 W4A8 kernels on SM90/H20.

The main goal is to let one resident MXFP4 weight representation be consumed
by either:

- explicit group scaling after WGMMA; or
- fused E8M0 scaling during register-side MXFP4 dequantization.

The selection is carried by `ComputeConfig.fuse_e8m0_scale`, while
`LayerConfig.use_shared_e8m0_scale_storage` describes the persistent tensor
representation. Switching the compute path does not transform, copy, or
replace the resident weight tensors.

This is intentionally a **Draft**. The API, storage contract, correctness
coverage, and small-M wins are implemented and validated. A full H20 TP8
shape sweep also identified a remaining W2 performance gap, documented below,
that must be addressed before proposing production enablement.

## Motivation

Humming currently makes `use_fused_e8m0_scale` a layer/storage decision:

- fused-E8M0 uses a mode-2 MXFP4 layout optimized for a compact dequant LUT;
- explicit group scaling uses a mode-3 layout and applies the E8M0 scale to
  accumulator fragments.

The preferred path changes with workload shape. On Kimi-K3 decode, explicit
group scaling was substantially faster for small expert-local M. On prefill,
native fused-E8M0 was faster. Keeping both native layouts would require a
weight-sized duplicate, which is not acceptable for these models.

This patch explores the alternative: one group-friendly physical layout with
two compiled compute paths selected per launch / CUDA Graph bucket.

## Design

### 1. Persistent layer/storage contract

`LayerConfig.use_shared_e8m0_scale_storage=True` is currently restricted to:

- FP8 E4M3 activations;
- MXFP4 E2M1 weights;
- E8M0 group-size-32 weight scales;
- per-token activation scales (`input_scale_group_size=0`);
- WGMMA;
- no zero point and no packed-K layout.

Load-time processing runs once:

1. `process_fused_e8m0_scale` produces the processed MXFP4 payload, a small
   relative exponent `s in [1, 12]`, and a per-expert FP32 secondary scale;
2. the primary scale is stored as native E8M0 byte `S = s + 127`;
3. the weight is packed in group-friendly mode-3 layout;
4. `weight_scale_2` is retained for both runtime paths.

The explicit path therefore consumes:

```text
2^(S - 127) * weight_scale_2 == 2^s * weight_scale_2
```

No weight-sized duplicate or runtime conversion kernel is introduced.

### 2. Runtime compute selection

`ComputeConfig.fuse_e8m0_scale` has three states:

- `None`: preserve the layer default;
- `False`: compile/select the explicit accumulator-scale path;
- `True`: compile/select the shared fused-dequant path.

`HummingKernel` includes the compute config in its cache key, so the two modes
produce distinct kernel IDs while reusing the same tensor pointers.

This is host/runtime kernel selection, not a divergent branch inside one
kernel. CUDA Graph users must select the mode before capture; replay keeps the
captured CUfunction fixed.

### 3. Group-friendly fused decoder

Mode-3 storage interleaves two WGMMA rows, and therefore two E8M0 scales, in a
packed FP4 word. The new decoder:

1. reconstructs the WGMMA register-A magnitude selectors;
2. builds two exponent LUTs;
3. emits four scaled FP8 registers directly.

The initial implementation used PRMT for selector packing. The current
implementation packs the byte-wide magnitudes with DP4A and reserves PRMT for
the exponent LUT. On the K3 W13 decode kernel this changes:

| Metric | Before DP4A | DP4A |
|---|---:|---:|
| Registers/thread | 96 | 96 |
| Static instructions | 3300 | 3308 |
| PRMT | 768 | 256 |
| IDP.4A | 0 | 512 |

The instruction count is similar, but distributing work away from the PRMT
pipe materially improves latency.

### 4. Narrow H20 large-M schedule corrections

Only for shared storage and `BM >= 48`:

- long K (`K > 1024`): disable Stream-K;
- short K (`K <= 512`): use at least grid 3072.

Native storage, small-M schedules, and batch-invariant paths are unchanged.

## How to use

```python
layer_config = LayerConfig(
    ...,
    use_shared_e8m0_scale_storage=True,
)

# Small-M / decode candidate
explicit_compute = ComputeConfig(
    gemm_type=GemmType.INDEXED,
    fuse_e8m0_scale=False,
)

# Large-M / prefill candidate
fused_compute = ComputeConfig(
    gemm_type=GemmType.INDEXED,
    fuse_e8m0_scale=True,
)
```

`get_heuristics_config(..., fuse_e8m0_scale=...)` can generate the tuning
table for either compute path.

This PR does **not** yet add an automatic phase/shape selector to a serving
framework.

## H20 performance evidence

### Exact K3 cells after DP4A

Fixed 1350 MHz H20, paired measurements:

| Cell | Shared fused before | Shared fused DP4A | Reduction |
|---|---:|---:|---:|
| W13 decode | 756.70 us | 638.22 us | 15.66% |
| W2 decode | 456.02 us | 385.63 us | 15.43% |
| W13 prefill T8192 | 4.438 ms | 4.235 ms | 4.57% |
| W2 prefill T8192 | 2.615 ms | 2.558 ms | 2.16% |

At small K3 decode cells, shared explicit remains the correct choice and is
within measurement noise of native explicit group storage. At prefill T8192,
shared fused is approximately 11% faster than shared explicit but remains
slower than native mode-2 fused storage.

### Initial three-arm TP8 sweep

Every integer token `shape_m` in `[1, 8192]` was measured on H20 for:

| Model | E/topK | TP8 W13 `(N,K)` | TP8 W2 `(N,K)` | routed-M range |
|---|---:|---:|---:|---:|
| Kimi-K3 | 896/16 | 768/3584 | 3584/384 | 16–131072 |
| DeepSeek-V4-Flash | 256/6 | 512/4096 | 4096/256 | 6–49152 |

Method:

- fixed 1350 MHz, no power/thermal throttling;
- nested deterministic random routing;
- INDEXED Humming;
- same raw tensors and routing within each paired run;
- L2-cold `triton.testing.do_bench`, 5 ms warmup / 20 ms measurement;
- native fused baseline, shared explicit, and shared fused at every point;
- current, previous-BM, and (for DSV4) next-BM counterfactual sweeps.

After selecting one deployable arm per contiguous config interval by median
speedup:

| W13+W2 subtotal | Winning points | Geomean | Median | Worst |
|---|---:|---:|---:|---:|
| Kimi-K3 | 1447 / 8192 | 0.9795x | 0.9682x | 0.8961x |
| DSV4-Flash | 2383 / 8192 | 0.9845x | 0.9793x | 0.8983x |

The result is **not all-line faster**. Even a non-deployable pointwise oracle
over every measured BM policy and both scale paths does not dominate:

- K3: 3163/8192 winning points, 1.0008x geomean;
- DSV4: 2778/8192 winning points, 0.9974x geomean.

Stage-level deployable selector results:

| Stage | Winning points | Geomean |
|---|---:|---:|
| K3 W13 | 1700 | 0.9965x |
| K3 W2 | 716 | 0.9519x |
| DSV4 W13 | 4425 | 1.0209x |
| DSV4 W2 | 679 | 0.9343x |

The main blocker is W2. With K=256/384 there are too few K turns to amortize
mode-3 selector packing and the dual-scale LUT. Six additional DSV4 W2 M1024
geometry candidates (BN128/256, WN32/64, stages 3/4, CTA2/3/4, TMA on/off)
all remained below native baseline; the best was 0.924x. This is not fixed by
a simple H20 heuristic boundary shift.

### Authoritative K3 four-arm follow-up

The initial sweep did not measure native explicit at every point. A follow-up
reran every K3 token `shape_m` in `[1, 8192]` with all four arms in the same
process and measurement contract:

1. native mode-3 explicit;
2. native mode-2 fused;
3. shared mode-3 explicit;
4. shared mode-3 fused.

The primary comparison is now:

```text
min(shared explicit, shared fused)
----------------------------------
min(native explicit, native fused)
```

K3 W13+W2 result:

| Metric | Value |
|---|---:|
| Winning token-M points | 825 / 8192 |
| Geomean speedup | 0.9681x |
| Median speedup | 0.9677x |
| Worst point | 0.9010x |
| Best point | 1.0202x |

Stage-level fastest-shared / fastest-native:

| Stage | Winning points | Geomean | Median |
|---|---:|---:|---:|
| K3 W13 | 1277 | 0.9831x | 0.9832x |
| K3 W2 | 555 | 0.9437x | 0.9429x |

The four-arm run corrects an important interpretation:

- shared explicit and native explicit are effectively the same path when the
  tuning config is matched; W2 explicit geomean is 0.9972x;
- at small M the fastest native arm is also explicit, so shared storage mostly
  matches rather than exceeds the native envelope;
- when native mode-2 fused becomes fastest, shared fused must overcome its
  layout bridge, and normally cannot.

Same-config BM32 SASS makes the bridge explicit:

| Stage/path | Static inst | PRMT | DP4A | FFMA |
|---|---:|---:|---:|---:|
| W13 native fused | 3120 | 224 | 0 | 0 |
| W13 shared fused | 4016 | 224 | 448 | 0 |
| W2 native fused | 1431 | 96 | 0 | 0 |
| W2 shared fused | 1815 | 96 | 192 | 0 |
| W13 native/shared explicit | 3801/3784 | 0/0 | 0/0 | 896/896 |
| W2 native/shared explicit | 1695/1679 | 0/0 | 0/0 | 384/384 |

The BM32 tuning IDs and register counts are matched within each native/shared
pair. The fused delta is therefore implementation work, not a heuristic or
spill artifact.

This follow-up also found and fixed one review issue: the BM>=48 H20 overrides
must apply only to `shared && fused`. Applying Stream-K/grid changes to shared
explicit polluted its comparison with native explicit. A regression test now
requires the shared explicit large-M schedule to remain identical to native
explicit.

### Crossover observation

There is no single decode/prefill threshold:

- BM8/BM16 normally prefer explicit;
- BM48/BM64 normally prefer fused;
- BM32 depends on the exact config family (`BN256/BK64` vs
  `BN128/BK128` can choose different paths);
- the faster shared arm can still be slower than native fused storage.

An eventual selector must key on at least stage + routed-M config interval +
kernel geometry, not only phase or block-M.

## Correctness and validation

- same-pointer test for `weight`, `weight_scale`, and `weight_scale_2`;
- shared explicit and shared fused checked against the independent Humming
  reference path;
- same-path repeat-bitwise checks and dummy-row canaries in exact harnesses;
- exact W13 and W2 tests on H20;
- H20 heuristic tests cover native isolation, BM>=48 long-K Stream-K-off,
  BM>=48 short-K grid, and unchanged small-M behavior;
- `22 passed, 2 skipped` across MXFP4 kernel, H20 heuristic, and JIT suites;
- `ruff check`, `ruff format --check`, and `git diff --check` pass.

## Known limitations / follow-ups

1. No serving integration or automatic runtime selector is included.
2. The shared contract is intentionally narrow: FP8 E4M3 per-token input,
   MXFP4 E2M1 + E8M0 group32, WGMMA, no zero point.
3. W2 K256/384 still trails native fused storage in mid/large-M regions.
4. The next optimization should change the load/dequant pipeline rather than
   add more heuristic branches. Candidate directions:
   - move mode-3 selector rearrangement earlier into the B load pipeline;
   - explore a third physical layout that keeps explicit scaling cheap while
     avoiding per-fragment DP4A in the fused path.
5. Real-checkpoint model-load and serving accuracy/performance gates are still
   required before production use.

## Review guide

The commit stack is intentionally split:

1. `feat: add runtime E8M0 scale mode switching`
2. `perf: use group-friendly shared E8M0 storage`
3. `perf: move shared E8M0 selector packing to DP4A`
4. `perf: tune shared E8M0 large-M schedules on H20`

Suggested review order:

1. LayerConfig / ComputeConfig contract and transform invariants;
2. mode-3 dual-scale decoder and WGMMA fragment mapping;
3. DP4A selector algebra and SASS;
4. narrowly gated H20 schedule changes and tests.

---

## Update (4281dae): measured W2 schedule + AUTO path selection (K3-gated)

**Root cause closed.** An exhaustive layout enumeration proves the mode-3 DP4A selector bridge is already optimal under the explicit-zero-tax constraint, and an in-warp code-motion prototype (bitwise-identical outputs) captured none of the oracle headroom — the compiler already schedules the chain against the WGMMA waits. The W2 fused gap is a certified floor, not an open bug.

**Measured W2 schedule.** shared + fused, `BM >= 48`, `K in [384, 512]` -> `BN128/WN32/stage3/CTA4/TMA, grid >= 3072`: 6584/6584 BM>=48 points win on K3 W2, shared-fused/native-fused geomean 0.942 -> 0.981. The K floor exists because DSV4-Flash W2 (K=256) regresses 6-8% under the same schedule.

**AUTO path selection.** Leaving `ComputeConfig.fuse_e8m0_scale` unset on a shared-storage INDEXED layer with a measured `(N, K, E)` shape now auto-selects the execution path per routed-M interval from measured winner bands (including a W13 fused pocket at routed-M (11456, 14336] where the explicit schedule collapses by up to 1.6x). Each interval carries `fuse_e8m0_scale`, so callers need no per-phase logic; unmeasured shapes, gemm types, and devices keep prior behaviour.

**Acceptance** — 3-arm production-path sweep (K3 TP8, integer M=1..8192, locked 1350 MHz):

| shared-AUTO vs | geomean | notes |
|---|---:|---|
| group-storage-only | **1.128** | 7930/8192 points ahead |
| fused-storage-only | 0.989 | decode band (M<=128) **+14.8%**, large-M -1.4%, BM32 band -8% (structural) |
| pointwise native envelope | 0.980 | zero selection headroom (matches the best-shared-arm oracle) |

Under a bimodal serving mix (decode cells + prefill chunks), shared-AUTO beats **both** single-storage schemes by ~6-7% with one resident weight copy.

![K3 TP8 acceptance sweep](https://raw.githubusercontent.com/guzekai01/humming/pr61-assets/docs/assets/k3_auto_vs_schemes_linear.png)

**Integration plumbing.** `use_shared_e8m0_scale_storage` is now exposed on `HummingWeightSchema` and forwarded by `prepare_layer_config`, so serving integrations can enable shared storage through the standard schema path (one flag at weight load; the runtime side needs no per-phase logic thanks to AUTO).

**Correctness / tests.** Shared arms are bitwise-equal to their native counterparts at every probed point; AUTO outputs are bitwise-equal to explicit path requests; the schedule changes are bitwise-neutral. `test_sm90_h20_heuristics.py` 17 passed, `test_mxfp4.py` 9 passed (incl. schema plumbing); ruff check/format clean.
