### PR TITLE
tune(sm90): improve W4A8 indexed MoE block-M selection

### DIFF
--- a/humming/tune/sm90.py
+++ b/humming/tune/sm90.py
@@ -12,6 +12,7 @@ from humming.tune.sm90_policies import (
     calc_sm90_num_block_list,
     select_grouped_scale,
     select_indexed_a16,
+    _use_w4a8_moe_bm_heuristic_v1,
 )
 from humming.utils.smem import estimate_smem_size_layer
 
@@ -104,6 +105,15 @@ class Sm90Heuristics(DeviceHeuristics):
             use_batch_invariant,
             gemm_type,
         )
+        if _use_w4a8_moe_bm_heuristic_v1(problem):
+            problem = cls._make_problem(
+                layer_config,
+                shape_m,
+                use_f16_accum,
+                use_batch_invariant,
+                gemm_type,
+                include_grid_size=True,
+            )
         return select_grouped_scale(problem).to_config()
 
     @classmethod
@@ -157,6 +167,15 @@ class Sm90Heuristics(DeviceHeuristics):
             include_grid_size=tune_indexed_a16,
         )
         if cls._uses_grouped_scale_candidates(layer_config):
+            if _use_w4a8_moe_bm_heuristic_v1(problem):
+                problem = cls._make_problem(
+                    layer_config,
+                    shape_m,
+                    use_f16_accum,
+                    use_batch_invariant,
+                    gemm_type,
+                    include_grid_size=True,
+                )
             return select_grouped_scale(problem)
         if not tune_indexed_a16:
             raise ValueError(

--- a/humming/tune/sm90_policies.py
+++ b/humming/tune/sm90_policies.py
@@ -67,6 +67,129 @@ def _select_sm90_block_m(
     return np.argmin(num_blocks_list).item() * 8 + 8
 
 
+# Provisional V1 constants. These are intentionally small and easy to
+# recalibrate with an H100 W4A8 MoE BM sweep.
+_W4A8_BM_V1_SEARCH_RADIUS = 32
+_W4A8_BM_V1_POOR_LAST_WAVE_UTIL = 0.25
+_W4A8_BM_V1_MAX_PADDING_REGRESSION = 0.10
+
+
+def _use_w4a8_moe_bm_heuristic_v1(problem: TuningProblem) -> bool:
+    """Return whether the production V1 BM selector applies."""
+    layer_config = problem.layer_config
+    return (
+        problem.device.sm_version == 90
+        and problem.gemm_type == GemmType.INDEXED
+        and layer_config.num_experts > 0
+        and layer_config.a_dtype == dtypes.float8e4m3
+        and layer_config.b_dtype == dtypes.float4e2m1
+        and layer_config.weight_scale_group_size == 32
+    )
+
+
+def _get_w4a8_moe_bm_candidates(
+    layer_config: LayerConfig,
+    max_block_m: int,
+) -> list[int]:
+    """Build the legal BM candidates for the active SM90 config."""
+    return [
+        block_m
+        for block_m in range(8, max_block_m + 1, 8)
+        if not (
+            layer_config.a_dtype == dtypes.int8
+            and block_m > 32
+            and block_m % 16 == 8
+        )
+    ]
+
+
+def _select_w4a8_moe_block_m_v1(
+    problem: TuningProblem,
+    max_block_m: int,
+) -> int:
+    """Select BM from expected per-expert M plus a conservative correction."""
+    if problem.device.num_sms is None:
+        raise ValueError("W4A8 BM V1 selection requires a device SM count")
+    layer_config = problem.layer_config
+    valid_candidates = _get_w4a8_moe_bm_candidates(layer_config, max_block_m)
+    if not valid_candidates:
+        raise ValueError("no legal W4A8 BM V1 candidates")
+
+    expected_m_per_expert = problem.shape_m / layer_config.num_experts
+    if expected_m_per_expert <= max_block_m:
+        primary_target = math.ceil(expected_m_per_expert / 8) * 8
+    else:
+        num_m_tiles = math.ceil(expected_m_per_expert / max_block_m)
+        primary_target = math.ceil(expected_m_per_expert / num_m_tiles / 8) * 8
+    primary_target = max(8, min(primary_target, max_block_m))
+    primary_bm = next(
+        (block_m for block_m in valid_candidates if block_m >= primary_target),
+        valid_candidates[-1],
+    )
+    num_sms = max(problem.device.num_sms, 1)
+
+    def estimate(block_m: int) -> dict[str, float | int]:
+        base, remainder = divmod(problem.shape_m, layer_config.num_experts)
+        base_blocks = math.ceil(base / block_m)
+        remainder_blocks = math.ceil((base + 1) / block_m)
+        total_m_blocks = (
+            (layer_config.num_experts - remainder) * base_blocks
+            + remainder * remainder_blocks
+        )
+        padded_m = (
+            (layer_config.num_experts - remainder) * base_blocks * block_m
+            + remainder * remainder_blocks * block_m
+        )
+        padding_ratio = max(padded_m - problem.shape_m, 0) / max(problem.shape_m, 1)
+        total_ctas = total_m_blocks * math.ceil(layer_config.shape_n / 128)
+        num_waves = math.ceil(total_ctas / num_sms) if total_ctas else 0
+        last_wave_util = 0.0
+        if num_waves:
+            last_wave_ctas = total_ctas - (num_waves - 1) * num_sms
+            last_wave_util = last_wave_ctas / num_sms
+        return {
+            "bm": block_m,
+            "num_waves": num_waves,
+            "last_wave_util": last_wave_util,
+            "padding_ratio": padding_ratio,
+        }
+
+    primary = estimate(primary_bm)
+    if primary["last_wave_util"] >= _W4A8_BM_V1_POOR_LAST_WAVE_UTIL:
+        return primary_bm
+    correction_candidates = [
+        block_m for block_m in valid_candidates
+        if abs(block_m - primary_bm) <= _W4A8_BM_V1_SEARCH_RADIUS
+    ]
+    winner = primary
+    for block_m in correction_candidates:
+        if block_m == primary_bm:
+            continue
+        neighbor = estimate(block_m)
+        wave_improved = (
+            neighbor["num_waves"] < primary["num_waves"]
+            or (
+                neighbor["num_waves"] == primary["num_waves"]
+                and neighbor["last_wave_util"] > primary["last_wave_util"]
+            )
+        )
+        padding_ok = neighbor["padding_ratio"] <= (
+            primary["padding_ratio"] + _W4A8_BM_V1_MAX_PADDING_REGRESSION
+        )
+        if not (wave_improved and padding_ok):
+            continue
+        winner_is_better = (
+            neighbor["num_waves"] < winner["num_waves"]
+            or (
+                neighbor["num_waves"] == winner["num_waves"]
+                and neighbor["last_wave_util"] > winner["last_wave_util"]
+            )
+        )
+        if winner_is_better:
+            winner = neighbor
+    return int(winner["bm"])
+
+
 def build_sm90_seed_config(problem: TuningProblem) -> dict:
     """Build the sparse seed config shared by legacy and indexed-A16 paths."""
     layer_config = problem.layer_config
@@ -208,56 +331,73 @@ def select_grouped_scale(
         max_block_m = 192
     else:
         max_block_m = 200
-    block_shape_m = _select_sm90_block_m(
-        layer_config,
-        problem.shape_m,
-        max_block_m,
+
+    origin_block_shape_m = _select_sm90_block_m(
+        layer_config, problem.shape_m, max_block_m
     )
-    block_ks = (256, 128, 64) if block_shape_m <= 32 else (128, 64)
+    use_w4a8_bm_v1 = _use_w4a8_moe_bm_heuristic_v1(problem)
+    block_shape_m = (
+        _select_w4a8_moe_block_m_v1(problem, max_block_m)
+        if use_w4a8_bm_v1
+        else origin_block_shape_m
+    )
+
+    # V1 changes BM only. Keep BK derivation tied to origin BM.
+    block_ks = (256, 128, 64) if origin_block_shape_m <= 32 else (128, 64)
     use_multicast = (
-        problem.gemm_type == GemmType.DENSE and problem.shape_m / block_shape_m >= 4
+        problem.gemm_type == GemmType.DENSE
+        and problem.shape_m / block_shape_m >= 4
     )
 
-    candidates = []
-    # Candidate order records measured preference; legality supplies fallbacks.
-    for block_shape_n, warp_shape_n in ((128, 32), (64, 16)):
-        for block_shape_k in block_ks:
-            multicast_values = (True, False) if use_multicast else (False,)
-            for multicast in multicast_values:
-                config = {
-                    "block_shape": (
-                        block_shape_m,
-                        block_shape_n,
-                        block_shape_k,
-                    ),
-                    "warp_shape": (
-                        block_shape_m,
-                        warp_shape_n,
-                        min(128, block_shape_k),
-                    ),
-                    "use_stream_k": not problem.use_batch_invariant,
-                    "use_f16_accum": problem.use_f16_accum,
-                    "num_stages": 4,
-                }
-                if problem.gemm_type != GemmType.INDEXED:
-                    config["use_warp_spec"] = True
-                    config["use_tma"] = True
-                    config["use_mbarrier"] = True
-                if multicast:
-                    config["multi_cast_size_a"] = 2
-                candidate = ScheduleCandidate.from_config(
-                    "grouped_scale_"
-                    f"n{block_shape_n}_k{block_shape_k}_"
-                    f"{'multicast' if multicast else 'direct'}",
-                    config,
-                )
-                candidates.append(fit_pipeline_stages(problem, candidate))
+    def build_candidates(candidate_block_m: int) -> list[ScheduleCandidate]:
+        candidates = []
+        for block_shape_n, warp_shape_n in ((128, 32), (64, 16)):
+            for block_shape_k in block_ks:
+                multicast_values = (True, False) if use_multicast else (False,)
+                for multicast in multicast_values:
+                    config = {
+                        "block_shape": (candidate_block_m, block_shape_n, block_shape_k),
+                        "warp_shape": (
+                            candidate_block_m,
+                            warp_shape_n,
+                            min(128, block_shape_k),
+                        ),
+                        "use_stream_k": not problem.use_batch_invariant,
+                        "use_f16_accum": problem.use_f16_accum,
+                        "num_stages": 4,
+                    }
+                    if problem.gemm_type != GemmType.INDEXED:
+                        config["use_warp_spec"] = True
+                        config["use_tma"] = True
+                        config["use_mbarrier"] = True
+                    if multicast:
+                        config["multi_cast_size_a"] = 2
+                    candidate = ScheduleCandidate.from_config(
+                        "grouped_scale_"
+                        f"n{block_shape_n}_k{block_shape_k}_"
+                        f"{'multicast' if multicast else 'direct'}",
+                        config,
+                    )
+                    candidates.append(fit_pipeline_stages(problem, candidate))
+        return candidates
 
-    analyses = tuple(analyze_candidate(problem, candidate) for candidate in candidates)
-    selected = next(
-        (analysis for analysis in analyses if analysis.legal),
-        None,
+    def analyze_candidates(candidate_block_m: int) -> tuple[CandidateAnalysis, ...]:
+        return tuple(
+            analyze_candidate(problem, candidate)
+            for candidate in build_candidates(candidate_block_m)
+        )
+
+    analyses = analyze_candidates(block_shape_m)
+    selected = next((analysis for analysis in analyses if analysis.legal), None)
+    reason = (
+        "selected V1 W4A8 BM with upstream grouped-scale legality checks"
+        if use_w4a8_bm_v1
+        else "selected the first legal measured-priority candidate"
     )
+    if selected is None and use_w4a8_bm_v1 and block_shape_m != origin_block_shape_m:
+        analyses = analyze_candidates(origin_block_shape_m)
+        selected = next((analysis for analysis in analyses if analysis.legal), None)
+        reason = "V1 BM rejected by upstream legality; fell back to origin BM"
     if selected is None:
         rejected = {
             analysis.candidate.candidate_id: analysis.rejection_reasons
@@ -270,7 +410,7 @@ def select_grouped_scale(
         family="grouped_scale",
         selected=selected.candidate,
         considered=analyses,
-        reason="selected the first legal measured-priority candidate",
+        reason=reason,
     )
 
 

--- a/tests/kernels/humming/test_sm90_w4a8_indexed.py
+++ b/tests/kernels/humming/test_sm90_w4a8_indexed.py
@@ -1,0 +1,46 @@
+"""Numerical correctness for the production SM90 W4A8 indexed-MoE path."""
+
+import pytest
+import torch
+
+from humming import dtypes
+from humming.config import ComputeConfig, GemmType, LayerConfig, MmaType
+from humming.testing import KernelTestCase, KernelTestRunner, skip_if_unsupported
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9,
+    reason="SM90 CUDA device required",
+)
+
+
+def test_sm90_w4a8_indexed_group32_shapes():
+    """Cover three BM/BK regimes without retaining a multi-GB reference."""
+    test_case = KernelTestCase(
+        name="sm90-w4a8-indexed-group32",
+        layer_config=LayerConfig(
+            shape_n=1024,
+            shape_k=1024,
+            num_experts=8,
+            a_dtype=dtypes.float8e4m3,
+            b_dtype=dtypes.float4e2m1,
+            c_dtype=dtypes.bfloat16,
+            bs_dtype=dtypes.bfloat16,
+            weight_scale_group_size=32,
+            mma_type=MmaType.WGMMA,
+        ),
+        compute_config=ComputeConfig(gemm_type=GemmType.INDEXED),
+        top_k=2,
+        seed=2026,
+        rtol=0.02,
+        atol=2.0,
+    )
+    config = test_case.layer_config
+    skip_if_unsupported(a_dtype=config.a_dtype, mma_type=config.mma_type.value)
+
+    results = KernelTestRunner(test_case).run((64, 128, 256))
+    assert [result.tuning_config.block_shape for result in results] == [
+        (16, 128, 256),
+        (32, 128, 128),
+        (64, 128, 128),
+    ]

--- a/tests/test_sm90_w4a8_heuristics.py
+++ b/tests/test_sm90_w4a8_heuristics.py
@@ -1,0 +1,107 @@
+"""SM90 W4A8 indexed-MoE heuristic coverage.
+
+These tests intentionally validate the production selector directly.  They do
+not benchmark kernels and do not depend on the removed experimental env var.
+"""
+
+import pytest
+import torch
+
+from humming import dtypes
+from humming.config import GemmType, LayerConfig, MmaType
+from humming.tune.candidate import DeviceProfile, TuningProblem
+from humming.tune.sm90 import Sm90Heuristics
+from humming.tune.sm90_policies import (
+    _get_w4a8_moe_bm_candidates,
+    _use_w4a8_moe_bm_heuristic_v1,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9,
+    reason="SM90 CUDA device required",
+)
+
+
+def _layer(shape_n: int = 4096, shape_k: int = 6144) -> LayerConfig:
+    return LayerConfig(
+        shape_n=shape_n,
+        shape_k=shape_k,
+        num_experts=256,
+        a_dtype=dtypes.float8e4m3,
+        b_dtype=dtypes.float4e2m1,
+        c_dtype=dtypes.bfloat16,
+        bs_dtype=dtypes.bfloat16,
+        weight_scale_group_size=32,
+        mma_type=MmaType.WGMMA,
+    )
+
+
+def _problem(layer, gemm_type, sm_version=90):
+    return TuningProblem(
+        layer_config=layer,
+        shape_m=4096,
+        gemm_type=gemm_type,
+        device=DeviceProfile(
+            name=f"sm{sm_version}",
+            sm_version=sm_version,
+            num_sms=132,
+            max_smem_size=227 * 1024,
+        ),
+    )
+
+
+def test_w4a8_indexed_selector_scope():
+    layer = _layer()
+    assert _use_w4a8_moe_bm_heuristic_v1(_problem(layer, GemmType.INDEXED))
+    assert not _use_w4a8_moe_bm_heuristic_v1(_problem(layer, GemmType.DENSE))
+    assert not _use_w4a8_moe_bm_heuristic_v1(
+        _problem(layer, GemmType.GROUPED_CONTIGUOUS)
+    )
+    assert not _use_w4a8_moe_bm_heuristic_v1(
+        _problem(layer, GemmType.GROUPED_MASKED)
+    )
+    assert not _use_w4a8_moe_bm_heuristic_v1(
+        _problem(layer, GemmType.INDEXED, sm_version=80)
+    )
+
+
+def test_w4a8_candidates_are_dynamic_and_legal():
+    candidates = _get_w4a8_moe_bm_candidates(_layer(), max_block_m=192)
+    assert candidates == list(range(8, 193, 8))
+    assert candidates
+    assert all(8 <= bm <= 192 and bm % 8 == 0 for bm in candidates)
+
+
+@pytest.mark.parametrize("shape_n,shape_k", [(4096, 6144), (6144, 2048)])
+@pytest.mark.parametrize(
+    ("routed_m", "expected_bm", "expected_bk"),
+    [
+        (4096, 16, 256),
+        (8192, 32, 128),
+        (16384, 64, 128),
+    ],
+)
+def test_w4a8_indexed_config_changes_bm_only(
+    monkeypatch,
+    shape_n,
+    shape_k,
+    routed_m,
+    expected_bm,
+    expected_bk,
+):
+    monkeypatch.setattr(
+        Sm90Heuristics,
+        "get_num_sms",
+        classmethod(lambda cls: 132),
+    )
+    config = Sm90Heuristics.get_config(
+        _layer(shape_n, shape_k),
+        routed_m,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    assert config["block_shape"] == (expected_bm, 128, expected_bk)
+    assert config["warp_shape"] == (expected_bm, 32, 128)
+    assert config["num_stages"] == 4
+    assert config["use_stream_k"] is True


### PR DESCRIPTION
## Summary

- Add a routed-M-aware `BLOCK_M` selector for SM90 indexed MoE GEMMs with FP8 E4M3 activations and FP4 E2M1 weights using weight scale group size 32.
- Generate legal BM candidates dynamically from the active SM90 `max_block_m`.
- Use deterministic per-expert estimates with a local wave/padding correction.
- Keep the existing configuration policy unchanged outside the targeted path.

## Motivation

The existing SM90 indexed MoE heuristic selects `BLOCK_M` by minimizing an estimated block count based on a sampled routing distribution. For medium and large routed-M workloads, this can select overly large BM values.

For a given minimum per-expert M-tile count, a smaller BM that preserves the same tile count can reduce padding without increasing the primary tile count. The new selector uses the expected routed rows per expert to determine the primary BM regime, then considers nearby legal candidates when the estimated last CTA wave is poorly utilized.

## Implementation

The new selector is enabled only when all of the following are true:

- SM90
- `num_experts > 0`
- `GemmType.INDEXED`
- activation dtype is FP8 E4M3
- weight dtype is FP4 E2M1
- weight scale group size is 32

Legal BM candidates are generated dynamically as 8-row-aligned values from 8 through the active `max_block_m`, while retaining the existing dtype-specific legality constraints.

The primary BM target is derived from:

```text
expected_m_per_expert = routed_m / num_experts
```

For workloads above `max_block_m`, the selector estimates the minimum number of M tiles required per expert and chooses a compact BM that preserves that tile count. A local candidate window is then evaluated using estimated CTA-wave utilization and padding.

For the validated W4A8 `get_config2` path:

- `BN=128` is unchanged.
- `BK` is intentionally derived from the BM selected by the existing heuristic, so this change does not introduce a new K-reduction configuration.
- `num_stages=4` is unchanged.
- Stream-K policy is unchanged.
- Warp-N and warp-K are unchanged; warp-M follows the selected BM.
- No kernel, TMA layout, multicast, quantization, or epilogue implementation is changed.

The selector is integrated into the current SM90 candidate-based tuning structure and uses the existing candidate legality/resource checks.

The experimental runtime switch used during development has been removed. The new selector is the default behavior for the eligible path.

## Performance

Measured on an NVIDIA H100 80GB (SM90) using GLM-5.2-style indexed MoE shapes:

- W13: `K=6144, N=4096`
- W2: `K=2048, N=6144`
- `E=256`, `top_k=8`
- FP4 E2M1 weights
- FP8 E4M3 activations
- weight scale group size 32

`Routed M` denotes post-top-k routed rows. With `top_k=8`, the corresponding input-token count is `routed_m / 8`.

Routing is deterministic and evenly distributed across 256 experts for the reported cases.

The standalone kernel benchmark uses GEMM-only CUDA-event timing. Weight preparation, activation quantization, setup, JIT compilation, and warmup are outside the measured interval.

The A/B comparison uses separate source checkouts and subprocesses:

- baseline: upstream `main` / #59 at `8611853cbf60cab5abf1f1c01fd96c8f85f9315b`
- final: current PR head at `660444371df022fe8e153bb53b4449eb3c1ade09`

No forced-BM oracle or production environment switch is used.

| GEMM | Routed M | Baseline config | Final config | Baseline us | Final us | Speedup |
|:---|---:|:---|:---|---:|---:|---:|
| W13 | 2048 | BM24/BN128/BK256 | BM8/BN128/BK256 | 1234.725 | 1203.659 | +2.58% |
| W13 | 4096 | BM32/BN128/BK256 | BM16/BN128/BK256 | 1335.060 | 1246.423 | +7.11% |
| W13 | 8192 | BM56/BN128/BK128 | BM32/BN128/BK128 | 1831.129 | 1537.968 | +19.06% |
| W13 | 16384 | BM96/BN128/BK128 | BM64/BN128/BK128 | 3731.747 | 2055.866 | +81.52% |
| W2 | 2048 | BM24/BN128/BK256 | BM8/BN128/BK256 | 712.178 | 665.857 | +6.96% |
| W2 | 4096 | BM32/BN128/BK256 | BM16/BN128/BK256 | 752.906 | 699.421 | +7.65% |
| W2 | 8192 | BM56/BN128/BK128 | BM32/BN128/BK128 | 1100.789 | 920.162 | +19.63% |
| W2 | 16384 | BM96/BN128/BK128 | BM64/BN128/BK128 | 2169.567 | 1265.137 | +71.49% |

Across the 8 latest-main standalone GEMM cases:

- Geometric mean speedup: **+24.05%**
- Median speedup: **+13.35%**
- Regression cases: **0 / 8**

The gains increase with routed M, reaching about 19% at routed M=8192 and 71-82% at routed M=16384 for the tested W13/W2 shapes.

A reverse-order check on the two smallest W13 cases reproduced the gains at approximately:

- routed M=2048: **+3.19%**
- routed M=4096: **+6.00%**

This check was run with the PR checkout first and the upstream checkout second, and supports that the small-M gains are not explained by fixed benchmark execution order.

A standalone fused MoE wrapper benchmark covering W13, activation, W2, and combine reported:

| Routed M | Speedup |
| ---: | ---: |
| 2,048 | +3.56% |
| 4,096 | +5.60% |
| 8,192 | +16.54% |
| 16,384 | +69.73% |

Geometric mean fused-MoE speedup: **+21.27%**, with no regressions across the four tested routed-M values.

The fused wrapper includes activation quantization inside the timed path, unlike the standalone GEMM-only benchmark.

This is an operator-level benchmark, not a model-level end-to-end benchmark.

## Correctness

Current-head correctness validation used:

- baseline: upstream #59 at `8611853cbf60cab5abf1f1c01fd96c8f85f9315b`
- final: current PR head at `660444371df022fe8e153bb53b4449eb3c1ade09`
- FP4 E2M1 weights with group size 32
- FP8 E4M3 activations
- `GemmType.INDEXED`
- deterministic indexed routing
- `rtol=0.02`
- `atol=2.0`

The same 8 W13/W2 shapes used in the standalone performance table were validated:

| GEMM | Routed M | Baseline BM/BK | Final BM/BK | Max abs | Max rel | Mean abs | Status |
|:---|---:|:---|:---|---:|---:|---:|:---|
| W13 | 2048 | BM24/BK256 | BM8/BK256 | 0 | 0 | 0 | PASS |
| W13 | 4096 | BM32/BK256 | BM16/BK256 | 0 | 0 | 0 | PASS |
| W13 | 8192 | BM56/BK128 | BM32/BK128 | 0 | 0 | 0 | PASS |
| W13 | 16384 | BM96/BK128 | BM64/BK128 | 0 | 0 | 0 | PASS |
| W2 | 2048 | BM24/BK256 | BM8/BK256 | 0 | 0 | 0 | PASS |
| W2 | 4096 | BM32/BK256 | BM16/BK256 | 0 | 0 | 0 | PASS |
| W2 | 8192 | BM56/BK128 | BM32/BK128 | 0 | 0 | 0 | PASS |
| W2 | 16384 | BM96/BK128 | BM64/BK128 | 0 | 0 | 0 | PASS |

Summary:

- Cases: 8
- PASS: 8
- FAIL: 0

The baseline logical output is used as the reference. BM-specific padded routing metadata is regenerated independently for each checkout, and only the final logical routed output is compared.

The fused MoE wrapper validation also passed at routed-M values:

```text
2048, 4096, 8192, 16384
```

Repository tests additionally cover:

- selector dispatch scope
- dynamic BM candidate legality
- representative W13/W2 config selection
- FP4 E2M1 / FP8 E4M3 indexed MoE correctness
- preservation of the existing BK decision

## Validation

Targeted tests:

```bash
pytest -q \
  tests/test_sm90_w4a8_heuristics.py \
  tests/kernels/humming/test_sm90_w4a8_indexed.py
```

The targeted tests passed on an H100/SM90 environment.

Additional checks:

```bash
python -m py_compile \
  tests/test_sm90_w4a8_heuristics.py \
  tests/kernels/humming/test_sm90_w4a8_indexed.py

git diff --check
```

## Scope

This change is limited to the SM90 indexed MoE path with:

- FP8 E4M3 activations
- FP4 E2M1 weights
- weight scale group size 32
- `num_experts > 0`

The change does not modify:

- Dense GEMM dispatch
- Grouped-contiguous MoE dispatch
- Grouped-masked MoE dispatch
- other activation or weight dtype combinations
- other weight scale group sizes
- other GPU architectures
- kernel implementation
- quantization implementation
- TMA or multicast implementation
- epilogue logic
