### PR TITLE
tune(sm90): improve W4A16 indexed MoE block-M selection

### DIFF
--- a/humming/tune/candidate.py
+++ b/humming/tune/candidate.py
@@ -54,6 +54,26 @@ class TuningProblem:
         return min(self.shape_m, self.layer_config.num_experts)
 
 
+def estimate_indexed_m_blocks_uniform(
+    shape_m: int,
+    num_experts: int,
+    block_shape_m: int,
+) -> int:
+    """Estimate Indexed MoE M tiles from deterministic uniform routing."""
+    if shape_m <= 0:
+        raise ValueError("shape_m must be positive")
+    if num_experts <= 0:
+        raise ValueError("num_experts must be positive")
+    if block_shape_m <= 0:
+        raise ValueError("block_shape_m must be positive")
+
+    base, remainder = divmod(shape_m, num_experts)
+    return (
+        (num_experts - remainder) * math.ceil(base / block_shape_m)
+        + remainder * math.ceil((base + 1) / block_shape_m)
+    )
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class ScheduleCandidate:
     candidate_id: str
@@ -522,10 +542,25 @@ def _analyze_resources(
         and schedule.block_shape[1] > 0
         and problem.layer_config.shape_n % schedule.block_shape[1] == 0
     ):
+        if (
+            problem.device.sm_version == 90
+            and problem.gemm_type == GemmType.INDEXED
+            and problem.layer_config.num_experts > 0
+            and problem.layer_config.a_dtype.num_bits == 16
+            and problem.layer_config.b_dtype.num_bits == 4
+            and not problem.use_batch_invariant
+        ):
+            num_m_blocks = estimate_indexed_m_blocks_uniform(
+                problem.shape_m,
+                problem.layer_config.num_experts,
+                schedule.block_shape[0],
+            )
+        else:
+            num_m_blocks = problem.estimate_num_blocks_m(schedule.block_shape[0])
         num_output_tiles = (
             problem.layer_config.shape_n
             // schedule.block_shape[1]
-            * problem.estimate_num_blocks_m(schedule.block_shape[0])
+            * num_m_blocks
         )
 
     residency_limits: list[int] = []

--- a/humming/tune/sm90_policies.py
+++ b/humming/tune/sm90_policies.py
@@ -12,6 +12,7 @@ from humming.tune.candidate import (
     TuningDecision,
     TuningProblem,
     analyze_candidate,
+    estimate_indexed_m_blocks_uniform,
     fit_pipeline_stages,
 )
 
@@ -67,6 +68,150 @@ def _select_sm90_block_m(
     return np.argmin(num_blocks_list).item() * 8 + 8
 
 
+_W4A16_INDEXED_BM_SEARCH_RADIUS = 32
+_W4A16_INDEXED_BM_POOR_LAST_WAVE_UTIL = 0.25
+_W4A16_INDEXED_BM_MAX_PADDING_REGRESSION = 0.10
+_W4A16_INDEXED_BM_BOUNDARY_MAX_TILE_GAIN_RATIO = 0.05
+_W4A16_INDEXED_BM_BOUNDARY_MIN_PADDING_REGRESSION = 0.10
+_W4A16_INDEXED_BM_MAX = 64
+
+
+def _applies_w4a16_indexed_policy(problem: TuningProblem) -> bool:
+    """Return whether the SM90 W4A16 indexed policy applies."""
+    layer_config = problem.layer_config
+    return (
+        problem.device.sm_version == 90
+        and problem.gemm_type == GemmType.INDEXED
+        and layer_config.num_experts > 0
+        and layer_config.a_dtype.num_bits == 16
+        and layer_config.b_dtype.num_bits == 4
+        and not problem.use_batch_invariant
+    )
+
+
+def _select_conservative_indexed_a16_block_m(problem: TuningProblem) -> int:
+    """Return the conservative threshold-based indexed-A16 seed BM."""
+    layer_config = problem.layer_config
+    tokens_per_expert = problem.shape_m / layer_config.num_experts
+    first_threshold = 1.01 if layer_config.b_dtype.num_bits == 4 else 0.7
+    moe_block_size_configs = (
+        (8, first_threshold),
+        (16, 0.7),
+        (24, 0.8),
+        (32, 0.9),
+        (48, 0.9),
+        (64, 0.9),
+    )
+    for block_shape_m, threshold in moe_block_size_configs:
+        if tokens_per_expert / block_shape_m < threshold:
+            break
+    return block_shape_m
+
+
+def _select_w4a16_indexed_block_m(
+    problem: TuningProblem,
+    max_block_m: int,
+) -> int:
+    """Select the W4A16 seed BM from routed-M-aware grid estimates."""
+    if problem.device.num_sms is None:
+        raise ValueError("W4A16 BM selection requires a device SM count")
+    layer_config = problem.layer_config
+    valid_candidates = list(range(8, max_block_m + 1, 8))
+    if not valid_candidates:
+        raise ValueError("no legal W4A16 BM candidates")
+
+    expected_m_per_expert = problem.shape_m / layer_config.num_experts
+    if expected_m_per_expert <= max_block_m:
+        primary_target = math.ceil(expected_m_per_expert / 8) * 8
+    else:
+        num_m_tiles = math.ceil(expected_m_per_expert / max_block_m)
+        primary_target = math.ceil(expected_m_per_expert / num_m_tiles / 8) * 8
+    primary_target = max(8, min(primary_target, max_block_m))
+    primary_bm = next(
+        (block_m for block_m in valid_candidates if block_m >= primary_target),
+        valid_candidates[-1],
+    )
+    num_sms = max(problem.device.num_sms, 1)
+
+    def estimate(block_m: int) -> dict[str, float | int]:
+        total_m_blocks = estimate_indexed_m_blocks_uniform(
+            problem.shape_m,
+            layer_config.num_experts,
+            block_m,
+        )
+        padded_m = total_m_blocks * block_m
+        padding_ratio = max(padded_m - problem.shape_m, 0) / problem.shape_m
+        # Use the smallest indexed-A16 N tile only for conservative BM ranking.
+        # The indexed-A16 policy still owns the actual BN and CTA residency.
+        total_ctas = total_m_blocks * math.ceil(layer_config.shape_n / 128)
+        num_waves = math.ceil(total_ctas / num_sms) if total_ctas else 0
+        last_wave_util = 0.0
+        if num_waves:
+            last_wave_ctas = total_ctas - (num_waves - 1) * num_sms
+            last_wave_util = last_wave_ctas / num_sms
+        return {
+            "bm": block_m,
+            "num_m_tiles": total_m_blocks,
+            "num_waves": num_waves,
+            "last_wave_util": last_wave_util,
+            "padding_ratio": padding_ratio,
+        }
+
+    primary = estimate(primary_bm)
+    if primary_bm > 8:
+        smaller_bm = primary_bm - 8
+        smaller = estimate(smaller_bm)
+        tile_gain_ratio = (
+            smaller["num_m_tiles"] - primary["num_m_tiles"]
+        ) / smaller["num_m_tiles"]
+        padding_regression = (
+            primary["padding_ratio"] - smaller["padding_ratio"]
+        )
+        if (
+            tile_gain_ratio
+            < _W4A16_INDEXED_BM_BOUNDARY_MAX_TILE_GAIN_RATIO
+            and padding_regression
+            > _W4A16_INDEXED_BM_BOUNDARY_MIN_PADDING_REGRESSION
+        ):
+            primary_bm = smaller_bm
+            primary = smaller
+    if primary["last_wave_util"] >= _W4A16_INDEXED_BM_POOR_LAST_WAVE_UTIL:
+        return primary_bm
+    correction_candidates = [
+        block_m
+        for block_m in valid_candidates
+        if abs(block_m - primary_bm) <= _W4A16_INDEXED_BM_SEARCH_RADIUS
+    ]
+    winner = primary
+    for block_m in correction_candidates:
+        if block_m == primary_bm:
+            continue
+        neighbor = estimate(block_m)
+        wave_improved = (
+            neighbor["num_waves"] < primary["num_waves"]
+            or (
+                neighbor["num_waves"] == primary["num_waves"]
+                and neighbor["last_wave_util"] > primary["last_wave_util"]
+            )
+        )
+        padding_ok = neighbor["padding_ratio"] <= (
+            primary["padding_ratio"]
+            + _W4A16_INDEXED_BM_MAX_PADDING_REGRESSION
+        )
+        if not (wave_improved and padding_ok):
+            continue
+        winner_is_better = (
+            neighbor["num_waves"] < winner["num_waves"]
+            or (
+                neighbor["num_waves"] == winner["num_waves"]
+                and neighbor["last_wave_util"] > winner["last_wave_util"]
+            )
+        )
+        if winner_is_better:
+            winner = neighbor
+    return int(winner["bm"])
+
+
 def build_sm90_seed_config(problem: TuningProblem) -> dict:
     """Build the sparse seed config shared by legacy and indexed-A16 paths."""
     layer_config = problem.layer_config
@@ -83,20 +228,15 @@ def build_sm90_seed_config(problem: TuningProblem) -> dict:
         max_block_m = 176
 
     if tune_indexed_a16:
-        # Bound padding when only a few routed rows land on each expert.
-        tokens_per_expert = problem.shape_m / layer_config.num_experts
-        first_threshold = 1.01 if layer_config.b_dtype.num_bits == 4 else 0.7
-        moe_block_size_configs = (
-            (8, first_threshold),
-            (16, 0.7),
-            (24, 0.8),
-            (32, 0.9),
-            (48, 0.9),
-            (64, 0.9),
+        conservative_block_m = _select_conservative_indexed_a16_block_m(problem)
+        block_shape_m = (
+            _select_w4a16_indexed_block_m(
+                problem,
+                min(max_block_m, _W4A16_INDEXED_BM_MAX),
+            )
+            if _applies_w4a16_indexed_policy(problem)
+            else conservative_block_m
         )
-        for block_shape_m, threshold in moe_block_size_configs:
-            if tokens_per_expert / block_shape_m < threshold:
-                break
     else:
         block_shape_m = _select_sm90_block_m(
             layer_config,
@@ -391,6 +531,7 @@ def select_indexed_a16(
 ) -> TuningDecision:
     if problem.device.num_sms is None:
         raise ValueError("indexed-A16 selection requires a device SM count")
+
     base = fit_pipeline_stages(
         problem,
         ScheduleCandidate.from_config(
@@ -430,14 +571,26 @@ def select_indexed_a16(
     base_analysis = analyses[base_option]
     if not base_analysis.legal:
         raise AssertionError(base_analysis.rejection_reasons)
-    eligible_reasons = {
-        base_option: "selected the base indexed-A16 schedule",
-    }
 
-    if half_option is not None:
-        half_analysis = analyses[half_option]
+    half_analysis = analyses.get(half_option) if half_option is not None else None
+    prefer_half_k = (
+        _applies_w4a16_indexed_policy(problem)
+        and base_analysis.candidate.block_shape[0] >= 32
+        and half_analysis is not None
+        and half_analysis.legal
+    )
+    if prefer_half_k:
+        assert half_option is not None
+        selected = half_option
+        selection_reason = "halved K because BM is at least 32"
+    else:
+        eligible_reasons = {
+            base_option: "selected the base indexed-A16 schedule",
+        }
         if (
-            base_analysis.candidate.num_ctas_per_sm == 1
+            half_option is not None
+            and half_analysis is not None
+            and base_analysis.candidate.num_ctas_per_sm == 1
             and half_analysis.legal
             and half_analysis.candidate.num_ctas_per_sm
             > base_analysis.candidate.num_ctas_per_sm
@@ -446,34 +599,36 @@ def select_indexed_a16(
                 "halved K because it increased CTA residency"
             )
 
-    for option in options:
-        if option.transform != "split_n_widen_k":
-            continue
-        assert option.parent is not None
-        parent_reason = eligible_reasons.get(option.parent)
-        analysis = analyses[option]
-        parent_analysis = analyses[option.parent]
-        if (
-            parent_reason is not None
-            and analysis.legal
-            and analysis.candidate.num_ctas_per_sm
-            > parent_analysis.candidate.num_ctas_per_sm
-            and analysis.waves is not None
-            and parent_analysis.waves is not None
-            and analysis.waves <= parent_analysis.waves
-        ):
-            eligible_reasons[option] = (
-                f"{parent_reason}; split N and widened K without adding a grid wave"
-            )
-    selected = max(
-        eligible_reasons,
-        key=lambda option: option.priority,
-    )
+        for option in options:
+            if option.transform != "split_n_widen_k":
+                continue
+            assert option.parent is not None
+            parent_reason = eligible_reasons.get(option.parent)
+            analysis = analyses[option]
+            parent_analysis = analyses[option.parent]
+            if (
+                parent_reason is not None
+                and analysis.legal
+                and analysis.candidate.num_ctas_per_sm
+                > parent_analysis.candidate.num_ctas_per_sm
+                and analysis.waves is not None
+                and parent_analysis.waves is not None
+                and analysis.waves <= parent_analysis.waves
+            ):
+                eligible_reasons[option] = (
+                    f"{parent_reason}; split N and widened K without adding a grid wave"
+                )
+        selected = max(
+            eligible_reasons,
+            key=lambda option: option.priority,
+        )
+        selection_reason = eligible_reasons[selected]
 
-    final_candidate = analyses[selected].candidate.with_updates(
+    selected_analysis = analyses[selected]
+    final_candidate = selected_analysis.candidate.with_updates(
         use_stream_k=(
-            bool(analyses[selected].candidate.get("use_stream_k", True))
-            and analyses[selected].num_output_tiles < problem.device.num_sms
+            bool(selected_analysis.candidate.get("use_stream_k", True))
+            and selected_analysis.num_output_tiles < problem.device.num_sms
         )
     )
     final_analysis = analyze_candidate(problem, final_candidate)
@@ -487,5 +642,5 @@ def select_indexed_a16(
             final_analysis if option is selected else analyses[option]
             for option in options
         ),
-        reason=eligible_reasons[selected],
+        reason=selection_reason,
     )

--- a/tests/test_sm90_w4a16_heuristics.py
+++ b/tests/test_sm90_w4a16_heuristics.py
@@ -1,0 +1,361 @@
+"""CPU-only coverage for the SM90 W4A16 indexed policy."""
+
+import dataclasses
+
+import pytest
+
+from humming import dtypes
+from humming.config import GemmType, LayerConfig, MmaType
+from humming.tune.candidate import (
+    DeviceProfile,
+    ScheduleCandidate,
+    TuningProblem,
+    analyze_candidate,
+    estimate_indexed_m_blocks_uniform,
+)
+from humming.tune.sm90 import Sm90Heuristics
+from humming.tune.sm90_policies import (
+    Sm90CandidatePolicy,
+    _select_conservative_indexed_a16_block_m,
+    _select_w4a16_indexed_block_m,
+    _applies_w4a16_indexed_policy,
+    build_sm90_seed_config,
+    select_indexed_a16,
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_sm_count(monkeypatch):
+    monkeypatch.setattr(
+        Sm90Heuristics,
+        "get_num_sms",
+        classmethod(lambda cls: 132),
+    )
+
+
+def _layer(
+    *,
+    a_dtype=dtypes.bfloat16,
+    b_dtype=dtypes.float4e2m1,
+    num_experts: int = 256,
+) -> LayerConfig:
+    return LayerConfig(
+        shape_n=1024,
+        shape_k=4096,
+        num_experts=num_experts,
+        a_dtype=a_dtype,
+        b_dtype=b_dtype,
+        c_dtype=dtypes.bfloat16,
+        bs_dtype=dtypes.bfloat16,
+        weight_scale_group_size=32,
+        mma_type=MmaType.WGMMA,
+    )
+
+
+def _problem(
+    *,
+    shape_m: int = 4096,
+    layer: LayerConfig | None = None,
+    gemm_type: GemmType = GemmType.INDEXED,
+    sm_version: int = 90,
+    use_batch_invariant: bool = False,
+    use_f16_accum: bool = False,
+) -> TuningProblem:
+    return TuningProblem(
+        layer_config=layer or _layer(),
+        shape_m=shape_m,
+        gemm_type=gemm_type,
+        device=DeviceProfile(
+            name=f"sm{sm_version}",
+            sm_version=sm_version,
+            num_sms=132,
+            max_smem_size=227 * 1024,
+        ),
+        use_batch_invariant=use_batch_invariant,
+        use_f16_accum=use_f16_accum,
+    )
+
+
+def _analysis(decision, candidate_id):
+    return next(
+        analysis
+        for analysis in decision.considered
+        if analysis.candidate.candidate_id == candidate_id
+    )
+
+
+def test_w4a16_indexed_policy_scope_is_strict():
+    assert _applies_w4a16_indexed_policy(_problem())
+    assert not _applies_w4a16_indexed_policy(
+        _problem(gemm_type=GemmType.DENSE)
+    )
+    assert not _applies_w4a16_indexed_policy(
+        _problem(gemm_type=GemmType.GROUPED_CONTIGUOUS)
+    )
+    assert not _applies_w4a16_indexed_policy(
+        _problem(use_batch_invariant=True)
+    )
+    assert not _applies_w4a16_indexed_policy(_problem(sm_version=80))
+    assert not _applies_w4a16_indexed_policy(
+        _problem(layer=_layer(a_dtype=dtypes.float8e4m3))
+    )
+    assert not _applies_w4a16_indexed_policy(
+        _problem(layer=_layer(b_dtype=dtypes.float8e4m3))
+    )
+    assert not _applies_w4a16_indexed_policy(
+        _problem(layer=_layer(num_experts=0))
+    )
+
+
+@pytest.mark.parametrize(
+    ("block_m", "expected_m_blocks"),
+    [(8, 512), (16, 256), (32, 256), (64, 256)],
+)
+def test_uniform_indexed_m_block_estimate(block_m, expected_m_blocks):
+    assert estimate_indexed_m_blocks_uniform(4096, 256, block_m) == expected_m_blocks
+
+
+def test_uniform_indexed_m_block_estimate_handles_remainder_experts():
+    assert estimate_indexed_m_blocks_uniform(8, 3, 2) == 5
+
+
+@pytest.mark.parametrize(
+    ("routed_m", "expected_bm"),
+    [
+        (2048, 8),
+        (2056, 8),
+        (2872, 16),
+        (4104, 16),
+        (6152, 24),
+        (8200, 32),
+    ],
+)
+def test_w4a16_block_m_transition_boundaries(routed_m, expected_bm):
+    assert _select_w4a16_indexed_block_m(
+        _problem(shape_m=routed_m),
+        max_block_m=64,
+    ) == expected_bm
+
+
+def test_seed_config_changes_only_w4a16_indexed_block_m():
+    problem = _problem(shape_m=4096)
+    seed = build_sm90_seed_config(problem)
+
+    assert _select_conservative_indexed_a16_block_m(problem) == 24
+    assert seed["block_shape"] == (16, 256, 128)
+    assert seed["warp_shape"] == (16, 64, 64)
+    assert seed["num_stages"] == 4
+    assert seed["use_stream_k"] is True
+
+
+def test_routed_m_aware_selector_is_capped_at_bm64():
+    default_seed = build_sm90_seed_config(_problem(shape_m=45056))
+    f16_accum_seed = build_sm90_seed_config(
+        _problem(shape_m=49152, use_f16_accum=True)
+    )
+
+    assert default_seed["block_shape"][0] == 64
+    assert f16_accum_seed["block_shape"][0] == 64
+
+
+def test_w4a16_analysis_uses_routed_m_tile_count():
+    problem = _problem(shape_m=4100)
+
+    def candidate(block_m):
+        return ScheduleCandidate.from_config(
+            f"bm{block_m}",
+            {
+                "block_shape": (block_m, 256, 128),
+                "warp_shape": (block_m, 64, 64),
+                "num_stages": 4,
+                "num_ctas_per_sm": 1,
+            },
+        )
+
+    bm8 = analyze_candidate(problem, candidate(8))
+    bm16 = analyze_candidate(problem, candidate(16))
+
+    assert bm8.legal
+    assert bm16.legal
+    assert bm8.num_output_tiles == 2064
+    assert bm16.num_output_tiles == 1040
+    assert bm8.waves == 16
+    assert bm16.waves == 8
+
+
+@pytest.mark.parametrize(
+    ("routed_m", "expected_bm"),
+    [
+        (2056, 8),
+        (8192, 32),
+    ],
+)
+def test_routed_m_aware_block_m_flows_through_production(
+    routed_m,
+    expected_bm,
+):
+    decision = Sm90Heuristics.get_tuning_decision(
+        _layer(),
+        shape_m=routed_m,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    assert decision.family == "indexed_a16"
+    assert decision.selected_analysis.legal
+    assert decision.selected.block_shape[0] == expected_bm
+
+
+def test_bm_below_32_keeps_conservative_half_k_policy():
+    decision = Sm90Heuristics.get_tuning_decision(
+        _layer(),
+        shape_m=2048,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    base = _analysis(decision, "indexed_a16_base")
+    half_k = _analysis(decision, "indexed_a16_half_k")
+    assert base.candidate.block_shape == (8, 256, 128)
+    assert half_k.candidate.block_shape == (8, 256, 64)
+    assert base.candidate.num_ctas_per_sm == 2
+    assert half_k.candidate.num_ctas_per_sm == 3
+    assert decision.selected == base.candidate
+    assert decision.reason == "selected the base indexed-A16 schedule"
+
+
+def test_bm_below_32_uses_half_k_for_conservative_residency_gain():
+    problem = _problem(shape_m=128)
+    problem = dataclasses.replace(
+        problem,
+        device=dataclasses.replace(
+            problem.device,
+            max_smem_per_sm=100_000,
+        ),
+    )
+
+    decision = select_indexed_a16(problem, Sm90CandidatePolicy())
+
+    base = _analysis(decision, "indexed_a16_base")
+    half_k = _analysis(decision, "indexed_a16_half_k")
+    assert base.candidate.block_shape[0] == half_k.candidate.block_shape[0] == 8
+    assert base.candidate.num_ctas_per_sm == 1
+    assert half_k.candidate.num_ctas_per_sm == 2
+    assert decision.selected == half_k.candidate
+    assert decision.reason == "halved K because it increased CTA residency"
+
+
+def test_bm_at_least_32_prefers_legal_half_k():
+    decision = Sm90Heuristics.get_tuning_decision(
+        _layer(),
+        shape_m=8192,
+        gemm_type=GemmType.INDEXED,
+    )
+
+    base = _analysis(decision, "indexed_a16_base")
+    half_k = _analysis(decision, "indexed_a16_half_k")
+    assert base.candidate.block_shape == (32, 256, 128)
+    assert half_k.candidate.block_shape == (32, 256, 64)
+    assert half_k.legal
+    assert decision.selected == half_k.candidate
+    assert decision.reason == "halved K because BM is at least 32"
+
+
+def test_bm_at_least_32_half_k_does_not_require_residency_gain(monkeypatch):
+    import humming.tune.sm90_policies as policies
+
+    original_analyze = policies._analyze_indexed_a16_candidate
+
+    def force_half_k_lower_residency(problem, candidate, policy):
+        analysis = original_analyze(problem, candidate, policy)
+        if candidate.candidate_id != "indexed_a16_half_k":
+            return analysis
+        forced_candidate = analysis.candidate.with_updates(num_ctas_per_sm=1)
+        return analyze_candidate(problem, forced_candidate)
+
+    monkeypatch.setattr(
+        policies,
+        "_analyze_indexed_a16_candidate",
+        force_half_k_lower_residency,
+    )
+    decision = select_indexed_a16(
+        _problem(shape_m=8192),
+        Sm90CandidatePolicy(),
+    )
+
+    base = _analysis(decision, "indexed_a16_base")
+    half_k = _analysis(decision, "indexed_a16_half_k")
+    assert base.candidate.num_ctas_per_sm == 2
+    assert half_k.candidate.num_ctas_per_sm == 1
+    assert half_k.legal
+    assert decision.selected == half_k.candidate
+
+
+def test_illegal_half_k_falls_back_to_base(monkeypatch):
+    import humming.tune.sm90_policies as policies
+
+    original_analyze = policies._analyze_indexed_a16_candidate
+
+    def reject_half_k(problem, candidate, policy):
+        analysis = original_analyze(problem, candidate, policy)
+        if candidate.candidate_id == "indexed_a16_half_k":
+            return dataclasses.replace(
+                analysis,
+                hard_violations=("synthetic half-K rejection",),
+            )
+        return analysis
+
+    monkeypatch.setattr(
+        policies,
+        "_analyze_indexed_a16_candidate",
+        reject_half_k,
+    )
+    decision = select_indexed_a16(
+        _problem(shape_m=8192),
+        Sm90CandidatePolicy(),
+    )
+
+    assert not _analysis(decision, "indexed_a16_half_k").legal
+    assert decision.selected.candidate_id == "indexed_a16_base"
+    assert decision.reason == "selected the base indexed-A16 schedule"
+
+
+def test_non_w4_indexed_a16_keeps_conservative_block_m():
+    problem = _problem(
+        shape_m=2048,
+        layer=_layer(b_dtype=dtypes.float8e4m3),
+    )
+    seed = build_sm90_seed_config(problem)
+
+    assert not _applies_w4a16_indexed_policy(problem)
+    assert _select_conservative_indexed_a16_block_m(problem) == 16
+    assert seed["block_shape"][0] == 16
+
+
+@pytest.mark.parametrize(
+    "problem",
+    [
+        _problem(layer=_layer(a_dtype=dtypes.float8e4m3)),
+        _problem(sm_version=80),
+        _problem(use_batch_invariant=True),
+    ],
+    ids=["a8-input", "non-sm90", "batch-invariant"],
+)
+def test_non_target_indexed_analysis_keeps_legacy_m_tile_estimate(problem):
+    candidate = ScheduleCandidate.from_config(
+        "non_target",
+        {
+            "block_shape": (8, 256, 128),
+            "warp_shape": (8, 32, 128),
+            "num_stages": 4,
+        },
+    )
+
+    assert analyze_candidate(problem, candidate).num_output_tiles == 1024
+
+
+def test_dense_m_tile_estimate_is_unchanged():
+    problem = _problem(
+        layer=_layer(num_experts=0),
+        gemm_type=GemmType.DENSE,
+    )
+
+    assert problem.estimate_num_blocks_m(32) == 128


### PR DESCRIPTION
## Summary

- Extend the existing SM90 indexed-A16 candidate policy with routed-M-aware `BLOCK_M` selection.
- Use deterministic per-expert tile estimates instead of relying only on coarse average-M thresholds.
- Add a small padding/tile trade-off guard around BM transitions to avoid overly aggressive increases in `BLOCK_M`.
- Prefer legal half-K (`BK=64`) configs for targeted W4A16 indexed cases when `BM >= 32`.
- Keep behavior unchanged outside the targeted SM90 W4A16 indexed path.

## Context

This builds on the SM90 indexed-A16 scheduling and bounded candidate framework introduced in #58 and #59.

The existing candidate flow already owns the indexed-A16 base schedule, legality checks, residency analysis, and schedule transforms. This PR keeps that structure intact and only extends the W4A16 indexed `BLOCK_M` selection and half-K preference.

It is based on the latest main including #65 and preserves the short-K large-M scheduling guard added there.

## Motivation

The existing indexed-A16 policy can switch to a larger `BLOCK_M` too aggressively near routed-M boundaries.

For MoE workloads, only a small subset of experts may cross the next BM boundary, while increasing BM for all experts can introduce substantially more padding for only a small reduction in M tiles.

The updated selector uses deterministic per-expert tile estimates to choose BM and applies a small guard when a larger BM provides little tile-count reduction but significantly increases padding.

This also avoids the observed `BK=128` performance cliff for larger W4A16 indexed tiles by preferring legal half-K configs when `BM >= 32`.

## Validation

Benchmarked on an NVIDIA H100 80GB HBM3 against the latest `upstream/main`.

Representative workloads:

- GLM-5.2
  - W13: `N=4096, K=6144`
  - W2: `N=6144, K=2048`
  - 256 experts, top-k=8

- DeepSeek-V4
  - W13: `N=4096, K=4096`
  - W2: `N=4096, K=2048`
  - 256 experts, top-k=6

132 routed-M cases were tested in total.

Performance:
- GLM-5.2 overall geomean: **+9.88%**
- DeepSeek-V4 overall geomean: **+11.85%**
- All-case geomean: **+10.83%**
- Median speedup: **+6.34%**
- Regressions >1%: **0**
- Regressions >2%: **0**

Several shapes around BM transition regions show substantially larger gains:

| Profile | Workload | M | Upstream BM/BN/BK | New BM/BN/BK | Upstream p50 | New p50 | Speedup |
| --- | --- | ---: | --- | --- | ---: | ---: | ---: |
| GLM-5.2 | W13 | 6152 | `32/256/128` | `24/256/128` | 2442.2 us | 1504.7 us | **+62.31%** |
| GLM-5.2 | W2 | 4920 | `32/256/128` | `24/256/128` | 1079.8 us | 759.5 us | **+42.17%** |
| DeepSeek-V4 | W13 | 6138 | `32/256/128` | `24/256/128` | 1476.2 us | 996.5 us | **+48.13%** |
| DeepSeek-V4 | W2 | 7362 | `32/256/128` | `32/256/64` | 778.4 us | 526.0 us | **+47.97%** |

The largest improvements occur where the existing policy selects a substantially more expensive configuration near a BM/BK transition, while unchanged regions retain the existing configuration and performance.

Correctness:
- All 132 cases passed
- Independent FP32 matmul reference
- `rtol=0.02`, `atol=2.0`
- Baseline and candidate use the same inputs, weights, scales, and deterministic routing