### PR TITLE
feat(sm100): add FP8 activation support

### DIFF
--- a/humming/config/config.py
+++ b/humming/config/config.py
@@ -100,8 +100,24 @@ class LayerConfig(BaseHummingConfig):
     @property
     def mxmma_supported(self):
         assert self.sm_version is not None
-        if self.sm_version // 10 != 12:
+        if self.sm_version // 10 not in (10, 12):
             return False
+        if self.sm_version // 10 == 10:
+            from humming.jit.runtime import KernelRuntime
+
+            return (
+                _cuda_compiler_version(KernelRuntime._get_compiler()) >= (12, 9)
+                and self.a_dtype in (dtypes.float8e4m3, dtypes.float8e5m2)
+                and self.b_dtype in (dtypes.float4e2m1, self.a_dtype)
+                and self.input_scale_group_size == 32
+                and self.weight_scale_group_size == 32
+                and self.is_group_weight_scale
+                and self.bs_dtype == dtypes.float8e8m0
+                and self.as_dtype in (None, dtypes.float8e8m0)
+                and not self.has_zero_point
+                and self.shape_n % 128 == 0
+                and self.shape_k % 128 == 0
+            )
         if not (self.is_group_weight_scale or self.is_channel_weight_scale):
             return False
         if (
@@ -303,6 +319,10 @@ class LayerConfig(BaseHummingConfig):
         assert self.mma_type is not None
         value = self.mma_type.value.lower()
         return ["mma", "wgmma", "umma", "mxmma"].index(value)
+
+    @property
+    def use_mxumma(self):
+        return self.mma_type == MmaType.MXMMA and self.sm_version // 10 == 10
 
     @property
     def mxmma_native_mixed(self) -> bool:

--- a/humming/config/mma.py
+++ b/humming/config/mma.py
@@ -485,8 +485,8 @@ class MmaOpClass:
         if mma_type == MmaType.MMA:
             return MmaOpClassImpl(m, n, k, a_dtype, b_dtype, cd_dtype)
         elif mma_type == MmaType.UMMA:
-            assert (m, n, k) == (16, 8, 16)
-            assert a_dtype == b_dtype == dtypes.bfloat16
+            assert (m, n, k) == (16, 8, 256 // a_dtype.num_bits)
+            assert a_dtype == b_dtype and a_dtype in (dtypes.bfloat16, dtypes.float8e4m3, dtypes.float8e5m2)
             assert cd_dtype == dtypes.float32
             return UmmaOpClassImpl(m, n, k, a_dtype, b_dtype, cd_dtype)
         elif mma_type == MmaType.WGMMA:

--- a/humming/forward.py
+++ b/humming/forward.py
@@ -26,6 +26,14 @@ def _prepare_input_scale(config: LayerConfig, input_scale: torch.Tensor) -> torc
     mx_scale_dtype = str(config.as_dtype) in ("float8e4m3", "float8e8m0")
     grouped_mxmma = config.mma_type == MmaType.MXMMA and config.input_scale_group_size > 0
     if mx_scale_dtype and grouped_mxmma and input_scale.dtype != torch.int32:
+        if config.use_mxumma and input_scale.ndim == 2:
+            group_size = config.input_scale_group_size
+            logical_groups = (config.shape_k - config.pad_shape_k) // group_size
+            packed_groups = (config.shape_k // group_size + 3) // 4 * 4
+            if input_scale.size(-1) == logical_groups and logical_groups < packed_groups:
+                input_scale = torch.nn.functional.pad(
+                    input_scale.view(torch.uint8), (0, packed_groups - logical_groups)
+                )
         packed_scale = input_scale.view(torch.int32)
         if input_scale.ndim == 3:
             packed_scale = packed_scale.reshape(input_scale.size(0), input_scale.size(1))
@@ -50,6 +58,7 @@ def may_process_input(
     token_scales: torch.Tensor | None = None,
     activation_type: str = "none",
     activation_impl: str | None = None,
+    disable_fast_math: bool = False,
     hadamard_block_size: int | None = None,
     layout: str = "normal",
     expert_layout: torch.Tensor | None = None,
@@ -93,6 +102,7 @@ def may_process_input(
         token_scales=token_scales,
         activation_type=activation_type,
         activation_impl=activation_impl,
+        disable_fast_math=disable_fast_math,
         hadamard_block_size=hadamard_block_size,
         layout=layout,
         expert_layout=expert_layout,
@@ -115,12 +125,16 @@ def may_quant_input(
         return inputs, None
     if input_scale is not None:
         config.check_device(inputs.device)
-        return inputs, input_scale
+        return inputs, _prepare_input_scale(config, input_scale)
     outputs, group_scales, token_scales = may_process_input(
         config,
         inputs=inputs,
         outputs=quanted_input,
-        m_major_scale=(config.mma_type == MmaType.MXMMA and config.input_scale_group_size > 0),
+        m_major_scale=(
+            config.mma_type == MmaType.MXMMA
+            and config.input_scale_group_size > 0
+            and not config.use_mxumma
+        ),
         use_pdl=use_pdl,
     )
     if token_scales is not None:
@@ -171,8 +185,8 @@ def humming_forward(
         if token_scales is not None:
             token_scales = token_scales.unsqueeze(-1)
         input_scale = group_scales if group_scales is not None else token_scales
-        if input_scale is not None:
-            input_scale = _prepare_input_scale(config, input_scale)
+    if input_scale is not None:
+        input_scale = _prepare_input_scale(config, input_scale)
 
     if isinstance(compute_config, dict):
         compute_config = json.dumps(compute_config)

--- a/humming/include/humming/memory/g2s_loader/loader_as.cuh
+++ b/humming/include/humming/memory/g2s_loader/loader_as.cuh
@@ -35,6 +35,7 @@ private:
   static constexpr uint32_t kProblemNumGroups = CEIL_DIV(ProblemShape::K - PadShape::K, kGroupSize);
   static constexpr uint32_t kNumGroups = CEIL_DIV(BlockShape::K, kGroupSize);
   static constexpr uint32_t kMxScaleVec = kPartMmaShapeK / kGroupSize;
+  static constexpr uint32_t kMxGmemStride = ProblemShape::K / kPartMmaShapeK * kMxScaleVec / 4;
   static constexpr uint32_t kLoadsPerGroup =
       kUseMxScale ? MAX(1u, 4 / kNumGroups) : CEIL_DIV(kGroupSize, BlockShape::K);
   static constexpr uint32_t kRowLoadIters = CEIL_DIV(BlockShape::M, kNumLoadThreads);
@@ -88,10 +89,22 @@ public:
     const uint32_t *gmem_ptr_load = reinterpret_cast<const uint32_t *>(gmem_ptr);
 
     constexpr uint32_t kNumRows = CEIL_DIV(BlockShape::K / kPartMmaShapeK * kMxScaleVec, 4);
-    constexpr uint32_t kMxGmemStride = ProblemShape::K / kPartMmaShapeK * kMxScaleVec / 4;
     constexpr uint32_t kNumInts = BlockShape::M * kNumRows;
 
-    if constexpr (kNumInts <= kNumLoadThreads) {
+    if constexpr (kIsIndexedGemm) {
+      PRAGMA_UNROLL
+      for (uint32_t i = 0; i < kRowLoadIters; i++) {
+        uint32_t row = i * kNumLoadThreads + thread_id;
+        uint32_t input_row = load_row_index[i];
+        PRAGMA_UNROLL
+        for (uint32_t group = 0; group < kNumRows; group++) {
+          legacy_load_pred<kUseCpAsync>(
+              gmem_ptr_load + input_row * kMxGmemStride + group,
+              smem_ptr_load + group * BlockShape::M + row,
+              row < BlockShape::M && input_row < shape_m);
+        }
+      }
+    } else if constexpr (kNumInts <= kNumLoadThreads) {
       uint32_t smem_offset = thread_id;
       uint32_t smem_row = smem_offset / BlockShape::M;
       uint32_t smem_col = smem_offset % BlockShape::M;
@@ -252,7 +265,7 @@ public:
           if constexpr (kMMajorInputScale)
             gmem_ptr = gmem_ptr_raw + ((col_offset / 4) * total_shape_m + MIN(row_offset, total_shape_m));
           else
-            gmem_ptr = gmem_ptr_raw + (row_offset * (kProblemNumGroups / 4) + col_offset / 4);
+            gmem_ptr = gmem_ptr_raw + (row_offset * kMxGmemStride + col_offset / 4);
         }
       } else if constexpr (kUseTma) {
         // tma loads via tensor map; gmem_ptr unused
@@ -262,7 +275,7 @@ public:
         gmem_ptr = gmem_ptr_raw + ((row_offset * kProblemNumGroups) + col_offset);
       }
     } else {
-      gmem_ptr = gmem_ptr_raw + col_offset;
+      gmem_ptr = gmem_ptr_raw + (kUseMxScale ? col_offset / 4 : col_offset);
 
       PRAGMA_UNROLL
       for (uint32_t i = 0; i < kRowLoadIters; i++) {

--- a/humming/include/humming/mma/all.cuh
+++ b/humming/include/humming/mma/all.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <humming/mma/mxmma.cuh>
+#include <humming/mma/mxumma.cuh>
 #include <humming/mma/wgmma.cuh>
 #include <humming/mma/wmma.cuh>
 #include <humming/mma/umma.cuh>
@@ -21,7 +22,7 @@ struct MmaSelector<MmaType::WGMMA, Ctx, ArithClass> {
 
 template <class Ctx, class ArithClass>
 struct MmaSelector<MmaType::MXMMA, Ctx, ArithClass> {
-  using Type = MXMMA<Ctx, ArithClass>;
+  using Type = typename std::conditional<Ctx::kUseUmma, MXUMMA<Ctx, ArithClass>, MXMMA<Ctx, ArithClass>>::type;
 };
 
 template <class Ctx, class ArithClass>

--- a/humming/include/humming/mma/mxumma.cuh
+++ b/humming/include/humming/mma/mxumma.cuh
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <humming/mma/mxmma.cuh>
+#include <humming/mma/umma.cuh>
+
+
+template <class Ctx, class ArithClass>
+struct MXUMMA : MXMMA<Ctx, ArithClass> {
+  using Base = MXMMA<Ctx, ArithClass>;
+  using BlockShape = typename Ctx::BlockShape;
+  using SharedStorage = typename Ctx::SharedStorage;
+  using MmaOpClass = typename Ctx::MmaOpClass;
+  using ElementA = typename Ctx::ElementA;
+  using ElementB = typename Ctx::ElementB;
+  using Base::ctx;
+  static constexpr uint32_t kOperandColumns = 32;
+  static constexpr uint32_t kScaleAColumn = 64;
+  static constexpr uint32_t kScaleBColumn = 68;
+  static constexpr uint32_t kAccumulatorColumn = 72;
+  static constexpr uint32_t kTmemColumns = 256;
+  static constexpr uint32_t kActivationType = std::is_same<ElementA, Float8E5M2>::value ? 1 : 0;
+  static constexpr uint32_t kWeightType = std::is_same<ElementB, Float4E2M1>::value ? 5 : kActivationType;
+
+  static_assert(std::is_same<ElementA, Float8E4M3>::value ||
+                std::is_same<ElementA, Float8E5M2>::value);
+  static_assert(MmaOpClass::kScaleVec == 1);
+  static_assert(BlockShape::N == 128 && BlockShape::K == 128);
+  static_assert(Ctx::kNumMathThreads == 128);
+
+  CUDA_INLINE MXUMMA(Ctx &ctx, ArithClass &arith) : Base(ctx, arith) {}
+
+  CUDA_INLINE static void init(SharedStorage &smem) {
+    if (threadIdx.x < 32) tcgen05_alloc<kTmemColumns>(cast_smem_ptr_to_uint(&smem.umma_tmem_col));
+    if (threadIdx.x == 0) __mbarrier_init(&smem.umma_mbar, 1);
+    __syncthreads();
+  }
+
+  CUDA_INLINE static void dealloc(SharedStorage &smem) {
+    if (threadIdx.x < 32) tcgen05_dealloc<kTmemColumns>(smem.umma_tmem_col);
+  }
+
+  CUDA_INLINE void zero_accum() {
+    first_issue = true;
+    operand_buffer = 0;
+  }
+
+  CUDA_INLINE void transform_b(uint32_t buffer_id, uint32_t iter_id) {
+    Base::transform_b(buffer_id, iter_id);
+    const uint32_t *values = reinterpret_cast<const uint32_t *>(this->regs_b[buffer_id]);
+    uint32_t address = ctx.smem.umma_tmem_col + operand_buffer * kOperandColumns + iter_id * 8;
+    tcgen05_st_16x128b_x2(address, values);
+    tcgen05_st_16x128b_x2(address | (16u << 16), values + 4);
+    if (iter_id == Ctx::kWarpIters - 1) {
+      tcgen05_wait_st();
+      tcgen05_fence_before_thread_sync();
+    }
+  }
+
+  CUDA_INLINE void run(uint32_t stage_id, uint32_t iter_id) {
+    if (iter_id != Ctx::kWarpIters - 1) return;
+    uint32_t base = ctx.smem.umma_tmem_col;
+    // Replicate scale rows across all four 32-lane TMEM partitions.
+    uint32_t weights[4], inputs[4];
+    const uint32_t *weight_scales = reinterpret_cast<const uint32_t *>(ctx.smem.stages[stage_id].bs);
+    const uint32_t *input_scales = reinterpret_cast<const uint32_t *>(ctx.smem.stages[stage_id].as);
+    PRAGMA_UNROLL
+    for (uint32_t i = 0; i < 4; i++) {
+      uint32_t row = ctx.lane_id() + i * 32;
+      // Canonical MXMMA words interleave two K groups and two N rows.
+      uint32_t offset = row / 16 * 8 + row % 8;
+      uint32_t shift = (row % 16 / 8) * 16;
+      weights[i] = ((weight_scales[offset] >> shift) & 0xffffu)
+          | ((weight_scales[BlockShape::N / 2 + offset] >> shift) << 16);
+      inputs[i] = row < BlockShape::M ? input_scales[row] : Base::kSFOneWord;
+    }
+    tcgen05_st_32x32b_x4(base + kScaleAColumn, weights);
+    tcgen05_st_32x32b_x4(base + kScaleBColumn, inputs);
+    tcgen05_wait_st();
+    tcgen05_fence_before_thread_sync();
+    if constexpr (!Ctx::kUseTmaA) {
+      if (threadIdx.x == 0) tma_fence_async_shared();
+    }
+    ctx.sync_math_threads();
+    tcgen05_fence_after_thread_sync();
+    if (threadIdx.x == 0) {
+      PRAGMA_UNROLL
+      for (uint32_t k = 0; k < 4; k++) {
+        const void *ptr = &ctx.smem.stages[stage_id].a[k * 2];
+        uint64_t descriptor = ((uint64_t(cast_smem_ptr_to_uint(ptr)) >> 4) & 0x3fff)
+            | (uint64_t(1) << 16) | (uint64_t(64) << 32)
+            | (uint64_t(1) << 46) | (uint64_t(2) << 61);
+        tcgen05_mma_mxfp8<BlockShape::M, kWeightType, kActivationType>(
+            base + kAccumulatorColumn,
+            base + operand_buffer * kOperandColumns + k * 8, descriptor,
+            base + kScaleAColumn, base + kScaleBColumn,
+            k, !first_issue || k != 0);
+      }
+      tcgen05_commit(cast_smem_ptr_to_uint(&ctx.smem.umma_mbar));
+    }
+    first_issue = false;
+    operand_buffer ^= 1;
+  }
+
+  CUDA_INLINE void wait_stage() {
+    mbarrier_wait(&ctx.smem.umma_mbar, phase);
+    phase ^= 1;
+    tcgen05_fence_after_thread_sync();
+  }
+
+  template <class T = uint32_t>
+  CUDA_INLINE T *final_regs_c_as_ptr() {
+    uint32_t lane = ctx.lane_id();
+    uint32_t source_lane = (lane & 24u) | ((lane & 3u) << 1) | ((lane >> 2) & 1u);
+    PRAGMA_UNROLL
+    for (uint32_t m = 0; m < BlockShape::M / 8; m++) {
+      uint32_t values[8];
+      tcgen05_ld_32x32b_x8(ctx.smem.umma_tmem_col + kAccumulatorColumn + m * 8, values);
+      tcgen05_wait_ld();
+      PRAGMA_UNROLL
+      for (uint32_t i = 0; i < 8; i++) values[i] = __shfl_sync(0xffffffff, values[i], source_lane);
+      umma_transpose_bit<1, 4>(values);
+      umma_transpose_bit<2, 8>(values);
+      umma_transpose_bit<4, 16>(values);
+      PRAGMA_UNROLL
+      for (uint32_t n = 0; n < 4; n++) {
+        this->regs_c[m / 2][n][m % 2 * 2] = __uint_as_float(values[n * 2]);
+        this->regs_c[m / 2][n][m % 2 * 2 + 1] = __uint_as_float(values[n * 2 + 1]);
+      }
+    }
+    return Base::template regs_c_as_ptr<T>();
+  }
+
+private:
+  bool first_issue = true;
+  uint32_t operand_buffer = 0;
+  uint32_t phase = 0;
+};

--- a/humming/include/humming/mma/umma.cuh
+++ b/humming/include/humming/mma/umma.cuh
@@ -33,7 +33,11 @@ struct UMMA : WMMA<Ctx, ArithClass> {
   static constexpr uint32_t kAccumulatorColumn = 2 * kOperandColumns;
   static constexpr uint32_t kTmemColumns = kAccumulatorColumn + BlockShape::M <= 128 ? 128 : 256;
 
-  static_assert(std::is_same<typename Ctx::ElementA, BFloat16>::value);
+  using ElementA = typename Ctx::ElementA;
+  static constexpr bool kFp8 = ElementA::kBits == 8;
+  static_assert(std::is_same<ElementA, BFloat16>::value ||
+                std::is_same<ElementA, Float8E4M3>::value ||
+                std::is_same<ElementA, Float8E5M2>::value);
   static_assert(BlockShape::N == 128 && BlockShape::K == 64);
   static_assert(BlockShape::M == 64 || BlockShape::M == 128);
   static_assert(WarpShape::M == BlockShape::M && WarpShape::N == 32 && WarpShape::K == BlockShape::K);
@@ -83,10 +87,16 @@ struct UMMA : WMMA<Ctx, ArithClass> {
       uint32_t base = ctx.smem.umma_tmem_col;
       PRAGMA_UNROLL
       for (uint32_t k = 0; k < Ctx::kWarpIters; k++) {
-        uint64_t descriptor = tcgen05_smem_desc_bf16(&ctx.smem.stages[stage_id].a[k * 2]);
-        tcgen05_mma_bf16<BlockShape::M>(base + kAccumulatorColumn,
-                                      base + operand_buffer * kOperandColumns + k * 8,
-                                      descriptor, !first_issue || k != 0);
+        auto *ptr = &ctx.smem.stages[stage_id].a[k * 2];
+        uint32_t operand = base + operand_buffer * kOperandColumns + k * 8;
+        if constexpr (kFp8) {
+          tcgen05_mma_fp8<BlockShape::M, std::is_same<ElementA, Float8E5M2>::value>(
+              base + kAccumulatorColumn, operand, tcgen05_smem_desc_fp8(ptr),
+              !first_issue || k != 0);
+        } else {
+          tcgen05_mma_bf16<BlockShape::M>(base + kAccumulatorColumn, operand,
+                                        tcgen05_smem_desc_bf16(ptr), !first_issue || k != 0);
+        }
       }
       tcgen05_commit(cast_smem_ptr_to_uint(&ctx.smem.umma_mbar));
     }

--- a/humming/include/humming/utils/context.cuh
+++ b/humming/include/humming/utils/context.cuh
@@ -53,7 +53,7 @@ struct KernelContext : LayerConfig_, ComputeConfig_, TuningConfig_ {
   static constexpr bool kIsGroupedGemm = kIsGroupedContiguousGemm || kIsGroupedMaskedGemm;
 
   static constexpr bool kUseWmma = LayerConfig::kMmaType == MmaType::MMA;
-  static constexpr bool kUseUmma = LayerConfig::kMmaType == MmaType::UMMA;
+  static constexpr bool kUseUmma = LayerConfig::kMmaType == MmaType::UMMA || (LayerConfig::kMmaType == MmaType::MXMMA && LayerConfig::kSmVersion / 10 == 10);
   static constexpr bool kUseWgmma = LayerConfig::kMmaType == MmaType::WGMMA;
   static constexpr bool kUseMxmma = LayerConfig::kMmaType == MmaType::MXMMA;
 

--- a/humming/include/humming/utils/ptx/tcgen05.cuh
+++ b/humming/include/humming/utils/ptx/tcgen05.cuh
@@ -82,3 +82,50 @@ CUDA_INLINE void tcgen05_ld_32x32b_x8(uint32_t address, uint32_t *values) {
         "=r"(values[4]), "=r"(values[5]), "=r"(values[6]), "=r"(values[7])
       : "r"(address) : "memory");
 }
+
+
+CUDA_INLINE uint64_t tcgen05_smem_desc_fp8(const void *ptr) {
+  // K-major, 64 FP8 per row, 64-byte swizzle.
+  return ((uint64_t(cast_smem_ptr_to_uint(ptr)) >> 4) & 0x3fff)
+         | (uint64_t(1) << 16) | (uint64_t(32) << 32)
+         | (uint64_t(1) << 46) | (uint64_t(4) << 61);
+}
+
+
+template <uint32_t kN, bool kE5M2>
+CUDA_INLINE void tcgen05_mma_fp8(uint32_t d, uint32_t a, uint64_t b, bool accumulate) {
+  constexpr uint32_t descriptor = (1u << 4) | (uint32_t(kE5M2) << 7)
+                                  | (uint32_t(kE5M2) << 10)
+                                  | ((kN / 8) << 17) | (8u << 24);
+  asm volatile(
+      "{\n"
+      "  .reg .pred p;\n"
+      "  setp.ne.b32 p, %4, 0;\n"
+      "  tcgen05.mma.cta_group::1.kind::f8f6f4 [%0], [%1], %2, %3, {%5, %5, %5, %5}, p;\n"
+      "}\n"
+      :: "r"(d), "r"(a), "l"(b), "r"(descriptor), "r"(uint32_t(accumulate)), "r"(0u)
+      : "memory");
+}
+
+
+CUDA_INLINE void tcgen05_st_32x32b_x4(uint32_t address, const uint32_t *values) {
+  asm volatile("tcgen05.st.sync.aligned.32x32b.x4.b32 [%0], {%1, %2, %3, %4};"
+               :: "r"(address), "r"(values[0]), "r"(values[1]),
+                  "r"(values[2]), "r"(values[3]) : "memory");
+}
+
+
+template <uint32_t kN, uint32_t kAType, uint32_t kBType>
+CUDA_INLINE void tcgen05_mma_mxfp8(uint32_t d, uint32_t a, uint64_t b,
+                            uint32_t sfa, uint32_t sfb, uint32_t scale_id,
+                            bool accumulate) {
+  constexpr uint32_t descriptor = (kAType << 7) | (kBType << 10)
+      | ((kN / 8) << 17) | (1u << 23) | (1u << 27);
+  uint32_t idesc = descriptor | (scale_id << 29) | (scale_id << 4);
+  asm volatile(
+      "{ .reg .pred p; setp.ne.b32 p, %6, 0;\n"
+      "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale "
+      "[%0], [%1], %2, %3, [%4], [%5], p; }"
+      :: "r"(d), "r"(a), "l"(b), "r"(idesc), "r"(sfa), "r"(sfb),
+         "r"(uint32_t(accumulate)) : "memory");
+}

--- a/humming/include/humming/utils/storage.cuh
+++ b/humming/include/humming/utils/storage.cuh
@@ -2,7 +2,7 @@
 
 #include <humming/utils/base.cuh>
 
-#if HUMMING_MMA_TYPE_ID == 2
+#if HUMMING_MMA_TYPE_ID == 2 || (HUMMING_MMA_TYPE_ID == 3 && HUMMING_SM_VERSION / 10 == 10)
 #define IF_USE_UMMA(x) x
 #else
 #define IF_USE_UMMA(x)

--- a/humming/kernel/humming.py
+++ b/humming/kernel/humming.py
@@ -115,7 +115,7 @@ class HummingKernel(KernelRuntime, LayerConfig, ComputeConfig, TuningConfig):
 
     def init_sm_version(self):
         super().init_sm_version()
-        if self.mma_type == MmaType.UMMA:
+        if self.mma_type == MmaType.UMMA or self.use_mxumma:
             assert self.sm_version // 10 == 10, "UMMA requires SM100 family"
             assert _cuda_compiler_version(self._get_compiler()) >= (12, 9), (
                 "UMMA sm_100f requires CUDA 12.9 or newer"
@@ -409,9 +409,15 @@ class HummingKernel(KernelRuntime, LayerConfig, ComputeConfig, TuningConfig):
     def check_config(self):
         assert self.num_threads <= 1024
         if self.mma_type == MmaType.UMMA:
-            assert self.a_dtype == self.c_dtype == dtypes.bfloat16, (
-                "UMMA requires BF16 activations and outputs"
-            )
+            assert (
+                self.a_dtype in (dtypes.bfloat16, dtypes.float8e4m3, dtypes.float8e5m2)
+                and self.c_dtype == dtypes.bfloat16
+            ), "UMMA requires BF16 or FP8 activations and BF16 outputs"
+            if self.a_dtype.num_bits == 8:
+                assert self.input_scale_group_size == 0
+                assert self.use_fused_e8m0_scale or not (
+                    self.is_group_weight_scale or self.is_block_weight_scale
+                ), "UMMA FP8 requires channel scales or fused MXFP4 scales"
             assert self.block_shape[0] in (64, 128)
             assert tuple(self.block_shape[1:]) == (128, 64)
             assert tuple(self.warp_shape) == (self.block_shape[0], 32, 64)
@@ -419,6 +425,15 @@ class HummingKernel(KernelRuntime, LayerConfig, ComputeConfig, TuningConfig):
             assert not self.use_f16_accum
             assert not self.use_pdl
             assert not self.reduce_overlap_last_stage_only
+            assert self.multi_cast_size_a == self.multi_cast_size_b == 1
+        if self.use_mxumma:
+            assert self.mxmma_supported
+            assert self.block_shape[0] in (64, 128)
+            assert tuple(self.block_shape[1:]) == (128, 128)
+            assert tuple(self.warp_shape) == (self.block_shape[0], 32, 128)
+            assert self.use_warp_spec and self.num_stages >= 3
+            assert not self.use_pdl and not self.reduce_overlap_last_stage_only
+            assert not self.use_stream_k
             assert self.multi_cast_size_a == self.multi_cast_size_b == 1
         assert not (self.mma_type == MmaType.MXMMA and self.use_f16_accum), (
             "MXMMA does not support FP16 accumulation"

--- a/humming/kernel/process_input.py
+++ b/humming/kernel/process_input.py
@@ -96,6 +96,7 @@ class ProcessInputKernel(KernelRuntime, BaseHummingConfig):
     # Activation
     activation_type: ActivationType | str = ActivationType.None_
     activation_impl: str = ""
+    disable_fast_math: bool = False
 
     # Quantization
     quant_mode: QuantizationMode | str = QuantizationMode.DynamicGroup

--- a/humming/ops/input/process.py
+++ b/humming/ops/input/process.py
@@ -36,6 +36,7 @@ class _ProcessInput:
     token_scales: torch.Tensor | None = None
     activation_type: ActivationType | str = "none"
     activation_impl: str | None = None
+    disable_fast_math: bool = False
     hadamard_block_size: int | None = None
     layout: LayoutType | str = "normal"
     expert_layout: torch.Tensor | None = None
@@ -336,6 +337,7 @@ class _ProcessInput:
             zero_invalid=self.zero_invalid and self.layout == LayoutType.GroupedPadded,
             activation_type=self.activation_type,
             activation_impl=self.activation_impl,
+            disable_fast_math=self.disable_fast_math,
             quant_mode=self.quant_mode,
             group_scale_dtype=self.group_scale_dtype,
             scale_layout=self.group_scale_layout,
@@ -373,6 +375,7 @@ def _prepare_process_input_op(
     group_scale_dtype: str | None = None,
     activation_type: str = "none",
     activation_impl: str | None = None,
+    disable_fast_math: bool = False,
     hadamard_block_size: int | None = None,
     layout: str = "normal",
     expert_layout: torch.Tensor | None = None,
@@ -395,6 +398,7 @@ def _prepare_process_input_op(
         token_scales=token_scales,
         activation_type=activation_type,
         activation_impl=activation_impl,
+        disable_fast_math=disable_fast_math,
         hadamard_block_size=hadamard_block_size,
         layout=layout,
         expert_layout=expert_layout,
@@ -429,6 +433,7 @@ def _prepare_process_input_op(
             quant_group_size,
             activation_type,
             activation_impl,
+            disable_fast_math,
             hadamard_block_size,
             layout,
             output_width,
@@ -461,6 +466,7 @@ def process_input(
     token_scales: torch.Tensor | None = None,
     activation_type: str = "none",
     activation_impl: str | None = None,
+    disable_fast_math: bool = False,
     hadamard_block_size: int | None = None,
     layout: str = "normal",
     expert_layout: torch.Tensor | None = None,
@@ -476,6 +482,7 @@ def process_input(
         group_scale_dtype=group_scale_dtype,
         activation_type=activation_type,
         activation_impl=activation_impl,
+        disable_fast_math=disable_fast_math,
         hadamard_block_size=hadamard_block_size,
         layout=layout,
         expert_layout=expert_layout,

--- a/humming/tune/sm100.py
+++ b/humming/tune/sm100.py
@@ -22,6 +22,33 @@ class Sm100Heuristics(Sm80Heuristics):
         use_batch_invariant: bool = False,
         gemm_type: GemmType = GemmType.DENSE,
     ):
+        if layer_config.use_mxumma:
+            indexed = gemm_type == GemmType.INDEXED
+            block_m = 64 if shape_m < 128 * (layer_config.num_experts or 1) else 128
+            smem_size = estimate_smem_size_layer(
+                layer_config,
+                (block_m, 128, 128),
+                gemm_type,
+                4,
+                warp_shape=(block_m, 32, 128),
+                use_mbarrier=True,
+                use_warp_spec=True,
+            )
+            num_ctas = 2 if 2 * smem_size <= cls.max_smem_size else 1
+            return {
+                "mma_type": MmaType.MXMMA.value,
+                "block_shape": (block_m, 128, 128),
+                "warp_shape": (block_m, 32, 128),
+                "num_stages": 4,
+                "num_ctas_per_sm": num_ctas,
+                "use_warp_spec": True,
+                "use_tma": True,
+                "use_tma_a": not indexed,
+                "use_tma_c": not indexed,
+                "use_stream_k": False,
+                "use_pdl": False,
+                "raster_group_m": 1,
+            }
         if layer_config.mma_type != MmaType.UMMA:
             return super().get_config(
                 layer_config, shape_m, use_f16_accum, use_batch_invariant, gemm_type

--- a/humming/utils/smem.py
+++ b/humming/utils/smem.py
@@ -162,7 +162,7 @@ def estimate_smem_size_layer(
             num_math_mbarriers += 1
         add(num_math_mbarriers * 8, 8)  # math_mbar
 
-    if layer_config.mma_type == MmaType.UMMA:
+    if layer_config.mma_type == MmaType.UMMA or layer_config.use_mxumma:
         add(4, 4)  # TMEM allocation
         add(8, 8)  # MMA completion barrier
 

--- a/tests/kernels/humming/test_umma.py
+++ b/tests/kernels/humming/test_umma.py
@@ -3,7 +3,7 @@ import dataclasses
 import pytest
 import torch
 
-from humming import dtypes
+from humming import dtypes, ops
 from humming.config import ComputeConfig, GemmType, LayerConfig, MmaType
 from humming.config.config import _cuda_compiler_version
 from humming.jit.runtime import KernelRuntime
@@ -401,3 +401,134 @@ def test_umma_grouped_metadata_limits_cta_residency():
         )
         assert tuning["num_ctas_per_sm"] == expected_ctas
         assert tuning["num_stages"] == 5
+
+
+@pytest.mark.parametrize("gemm_type", list(GemmType))
+@pytest.mark.parametrize(
+    "a_dtype,weight_values",
+    (
+        ("float8e4m3", dict(b_dtype="float8e4m3")),
+        ("float8e5m2", dict(b_dtype="float8e5m2")),
+        ("float8e4m3", dict(b_dtype="uint4")),
+        ("float8e4m3", WEIGHT_CONFIGS["mxfp4"]),
+    ),
+)
+def test_umma_fp8_channel_input_scales(a_dtype, weight_values, gemm_type):
+    """FP8 TS MMA preserves channel input scales and W4 dequantization."""
+    case = _case("fp8-channel", gemm_type, **weight_values)
+    case = dataclasses.replace(
+        case, layer_config=dataclasses.replace(case.layer_config, a_dtype=a_dtype, use_fused_e8m0_scale=None)
+    )
+    _assert_results(case, (1, 65, 257))
+
+
+@pytest.mark.parametrize("gemm_type", list(GemmType))
+@pytest.mark.parametrize(
+    "a_dtype,b_dtype",
+    (
+        ("float8e4m3", "float4e2m1"),
+        ("float8e4m3", "float8e4m3"),
+        ("float8e5m2", "float4e2m1"),
+        ("float8e5m2", "float8e5m2"),
+    ),
+)
+def test_mxumma_fp8_group32_scales(a_dtype, b_dtype, gemm_type, monkeypatch):
+    """Native MXFP8 consumes group32 E8M0 scales on both operands."""
+    monkeypatch.setattr(
+        "humming.testing.tuning.get_heuristics_config",
+        get_heuristics_config,
+    )
+    case = KernelTestCase(
+        name="mxumma-fp8",
+        layer_config=LayerConfig(
+            shape_n=256,
+            shape_k=768,
+            num_experts=0 if gemm_type == GemmType.DENSE else 4,
+            a_dtype=a_dtype,
+            b_dtype=b_dtype,
+            c_dtype="bfloat16",
+            as_dtype="float8e8m0",
+            bs_dtype="float8e8m0",
+            input_scale_group_size=32,
+            weight_scale_group_size=32,
+            mma_type=MmaType.MXMMA,
+        ),
+        compute_config=ComputeConfig(gemm_type=gemm_type),
+        top_k=2,
+        seed=2026,
+    )
+    runner = KernelTestRunner(case)
+    kernels = runner.prepare_kernels((1, 65, 257))
+    assert all(
+        HummingKernel._id2kernel[int(kernel[0][2])].use_mxumma
+        for variants in kernels.values()
+        for kernel in variants
+    )
+    results = runner.run((1, 65, 257))
+    assert {result.shape_m for result in results} == {1, 65, 257}
+    for result in results:
+        torch.testing.assert_close(result.outputs, result.outputs_ref, rtol=case.rtol, atol=case.atol)
+
+
+@pytest.mark.parametrize("prequantized", (False, True))
+@pytest.mark.parametrize("shape_k", (256, 1472, 2880))
+@pytest.mark.parametrize("shape_m", (17, 257))
+@pytest.mark.parametrize("gemm_type", (GemmType.DENSE, GemmType.GROUPED_CONTIGUOUS))
+def test_mxumma_public_input_scales(prequantized, shape_k, shape_m, gemm_type, monkeypatch):
+    """Logical K tails preserve packed scale pitch across tiles and experts."""
+    from humming.forward import humming_forward, may_quant_input
+
+    monkeypatch.setattr("humming.testing.tuning.get_heuristics_config", get_heuristics_config)
+    config = LayerConfig(
+        shape_n=256,
+        shape_k=(shape_k + 127) // 128 * 128,
+        pad_shape_k=(-shape_k) % 128,
+        num_experts=0 if gemm_type == GemmType.DENSE else 4,
+        a_dtype="float8e4m3",
+        b_dtype="float4e2m1",
+        c_dtype="bfloat16",
+        as_dtype="float8e8m0",
+        bs_dtype="float8e8m0",
+        input_scale_group_size=32,
+        weight_scale_group_size=32,
+    )
+    case = KernelTestCase(
+        name="mxumma-external-scales",
+        layer_config=config,
+        compute_config=ComputeConfig(gemm_type=gemm_type),
+        seed=2026,
+    )
+    runner = KernelTestRunner(case)
+    runner.prepare_weight()
+    torch.manual_seed(case.seed)
+    total_m = shape_m * max(config.num_experts, 1)
+    original = torch.randn(total_m, shape_k, device="cuda", dtype=torch.bfloat16)
+    inputs, scales, _ = ops.process_input(
+        original,
+        quant_mode="dynamic_group",
+        quant_dtype="float8e4m3",
+        quant_group_size=32,
+        group_scale_dtype="float8e8m0",
+    )
+    ref_inputs = inputs.float() * scales.float().repeat_interleave(32, dim=-1)
+    scale_bytes = scales.view(torch.uint8)
+    quanted, prepared = may_quant_input(config, inputs, input_scale=scale_bytes)
+    assert quanted.data_ptr() == inputs.data_ptr()
+    if shape_k % 128 == 0:
+        assert prepared.data_ptr() == scale_bytes.data_ptr()
+    assert prepared.dtype == torch.int32 and prepared.shape == (total_m, (shape_k + 127) // 128)
+    if not prequantized:
+        inputs, scale_bytes = may_quant_input(config, original)
+        assert scale_bytes.dtype == torch.int32 and scale_bytes.shape == prepared.shape
+    kwargs = {"compute_config": {"gemm_type": gemm_type.value}}
+    if config.num_experts:
+        kwargs["expert_layout"] = torch.arange(5, device="cuda", dtype=torch.int32) * shape_m
+        reference = torch.bmm(
+            ref_inputs.reshape(4, shape_m, shape_k), runner.weight_ref.transpose(1, 2)
+        ).flatten(0, 1)
+    else:
+        reference = ref_inputs @ runner.weight_ref.T
+    output = humming_forward(
+        config, inputs=inputs, input_scale=scale_bytes, **runner.kernel_tensors, **kwargs
+    )
+    torch.testing.assert_close(output.float(), reference, atol=0.05, rtol=0.01)

--- a/tests/process_input/test_transform.py
+++ b/tests/process_input/test_transform.py
@@ -156,3 +156,20 @@ def test_hadamard_involution(block_size):
     transformed = process_input(inputs, hadamard_block_size=block_size)[0]
     restored = process_input(transformed, hadamard_block_size=block_size)[0]
     torch.testing.assert_close(restored, inputs, rtol=1e-5, atol=1e-5)
+
+
+def test_precise_activation_keeps_subnormals_across_cached_variants():
+    """Opting out of fast math must affect both compiled code and its cache key."""
+    x = torch.full((1, 32), 2.0**-140, device="cuda", dtype=torch.float32)
+    expected = x / 3.0
+    for precise in [True, False, True]:
+        result = process_input(
+            x,
+            activation_type="unary",
+            activation_impl="a / 3.0f",
+            disable_fast_math=precise,
+        )[0]
+        if precise:
+            torch.testing.assert_close(result, expected, atol=0, rtol=0)
+        else:
+            assert torch.count_nonzero(result) == 0


### PR DESCRIPTION
Adds SM100-family FP8 activations to the existing UMMA path and native group-32 E8M0 MXFP4 × MXFP8 / MXFP8 × MXFP8 execution, with BF16 outputs. Dense, indexed, grouped-contiguous and grouped-masked GEMMs reuse the existing weight packing, routing and output handling.

The native path keeps activations in shared memory and stages canonical weight fragments and block scales into TMEM. Input scale normalization and indexed gathers use the physical packed row stride, including logical K tails such as GPT-OSS K2880 padded to K2944. Existing BF16 and ordinary FP8 automatic dispatch remain unchanged; the native MXFP8 contract uses BM64/BM128 with a bounded initial schedule. This is functional support, not a broad configuration-tuning sweep.

The existing input processor also gains an optional precise-math setting, including its cache keys. The vLLM companion needs this to preserve CUDA activation rounding when fusing activation and MXFP8 quantization; other callers retain the current default.

17 files, +465/-25. Publication tree is identical to the validated `4dc0f5d` snapshot. [Output staging #74](https://github.com/inclusionAI/humming/pull/74) is a separate follow-up; [A4 #75](https://github.com/inclusionAI/humming/pull/75) has overlapping shared implementation that must be reconciled before both support PRs merge. Open Humming PRs were checked: the current tuning PRs target SM90 and do not duplicate this support.

Validation on NVIDIA B300 (SM103), PyTorch 2.13.0+cu130, CUDA 13.0; the generated target is sm_100f, requiring CUDA >=12.9:

```sh
# From the Humming checkout, using the existing managed environment.
CUDA_VISIBLE_DEVICES=0 PYTHONPATH="$PWD" /home/mgoin/code/vllm/.venv/bin/python -m pytest tests/kernels/humming/test_umma.py -q
CUDA_VISIBLE_DEVICES=0 PYTHONPATH="$PWD" /home/mgoin/code/vllm/.venv/bin/python -m pytest tests/process_input/test_transform.py -k precise_activation -q
```

The implementation campaign passed 177 BF16/plain-FP8 cases, 17 native-format/layout cases, five shared indexed-loader cases and the public input-scale tests. The subsequent scale-tail correction passed 40 strict cases and 24 tensor-operation memchecks. The precise-math/cache regression passes. These counts describe the separate recorded runs, not one final full-suite invocation. Changed Python Ruff checks and `git diff --check` passed.

With the vLLM companion, actual GPT-OSS-20B MXFP4 weights run under TP2 with BF16 model dtype and group-32 MXFP8 activations. Full 1,319-question GSM8K, zero-shot/low reasoning/temperature 0: corrected A8 baseline scored 1221/1319 with the existing helper, or 1239/1319 with the common signed-decimal extraction audit; every response stopped normally. The numeric extractor has documented limitations, so this is a descriptive quality check, not an accuracy-equivalence claim. No DeepSeek/Kimi model weights or A4 model evaluation were used.

AI assistance: implementation, review and validation used OpenAI Codex, including GPT-6 Astra. Kept as a draft for maintainer review and integration with the companion changes.
