### PR TITLE
perf(sm100): stage native MXUMMA output directly

### DIFF
--- a/humming/include/humming/arith/epilogue_arith.cuh
+++ b/humming/include/humming/arith/epilogue_arith.cuh
@@ -52,6 +52,10 @@ private:
   static constexpr uint32_t kSizeBias = WarpShape::N / 4 * 16 / 32;
 
 public:
+  static constexpr bool kCanWriteNative =
+      std::is_same<ElementC, BFloat16>::value && kIsGroupInputScale &&
+      kIsGroupWeightScale && !kHasZeroPoint && kExpOffset.x == 0;
+
   uint32_t as[kSizeAS];
   uint32_t bs[MAX(kSizeBS, 2)];
   uint32_t dq_bs[MAX(kSizeDequantBS, 4)];
@@ -59,6 +63,37 @@ public:
   uint32_t bs2[kSizeBias];
   uint32_t gs = 0;
   uint32_t _dummy;
+
+  scalar_t native_bias;
+  scalar_t native_scale;
+
+  CUDA_INLINE void prepare_native_output() {
+    const uint32_t lane = threadIdx.x % 32;
+    auto select_channel = [&](const uint32_t *values) {
+      uint32_t pair = 0;
+      PRAGMA_UNROLL
+      for (uint32_t i = 0; i < 4; i++) {
+        uint32_t candidate = __shfl_sync(0xffffffff, values[i], lane % 8 / 2);
+        if (lane / 8 == i) pair = candidate;
+      }
+      return __ushort_as_bfloat16(pair >> ((lane % 2) * 16));
+    };
+    if constexpr (kHasBias) native_bias = select_channel(bias);
+    if constexpr (kIsChannelWeightScale2) native_scale = select_channel(bs2);
+  }
+
+  CUDA_INLINE __nv_bfloat16 apply_native_output(float value) {
+    if constexpr (kHasTensorWeightScale) value *= __uint_as_float(gs);
+    auto result = __float2bfloat16_rn(value);
+    if constexpr (kIsChannelWeightScale2 && kHasBias) {
+      result = __hfma(result, native_scale, native_bias);
+    } else if constexpr (kIsChannelWeightScale2) {
+      result = __hmul(result, native_scale);
+    } else if constexpr (kHasBias) {
+      result = __hadd(result, native_bias);
+    }
+    return result;
+  }
 
   CUDA_INLINE
   void may_process_f32_on_smem_write(uint32_t row, uint32_t col) {

--- a/humming/include/humming/epilogue/pipeline.cuh
+++ b/humming/include/humming/epilogue/pipeline.cuh
@@ -47,8 +47,10 @@ public:
     ctx.sync_math_threads();
   }
 
+  template <bool kNative = false>
   CUDA_INLINE
-  void call(uint32_t *regs_c_ptr) {
+  void call(uint32_t *regs_c_ptr, MMA *mma = nullptr) {
+    if constexpr (kNative) arith.prepare_native_output();
     ctx.sync_math_threads();
     if constexpr (BlockShape::K > WarpShape::K) smem_reducer.reduce(regs_c_ptr);
     static_assert(kNumWriteSplits == 1 || kNumWriteSplits == 2);
@@ -61,7 +63,13 @@ public:
     if (slice_count > 1) acquire_gmem_barrier();
     PRAGMA_UNROLL
     for (uint32_t i = 0; i < kNumWriteSplits; i++) {
-      smem_writer.write(regs_c_ptr, slice_count, i);
+      if constexpr (kNative) {
+        static_assert(kNumWriteSplits == 1 && !Ctx::kUseStreamK);
+        static_assert(BlockShape::K == WarpShape::K);
+        mma->write_native_output(arith);
+      } else {
+        smem_writer.write(regs_c_ptr, slice_count, i);
+      }
       if constexpr (Ctx::kUseTmaC) {
         if (ctx.is_math_thread()) tma_fence_async_shared();
       }

--- a/humming/include/humming/kernel/humming_ws.cuh
+++ b/humming/include/humming/kernel/humming_ws.cuh
@@ -250,7 +250,12 @@ __global__ __launch_bounds__(TuningConfig::kNumThreads, TuningConfig::kNumCtasPe
       s2r_pipe.load_channel(scheduler.slice_id);
 
       if constexpr (kReduceOverlapLastStageOnly) consumer.arrive(kNumStages);
-      epilogue.call(mma.final_regs_c_as_ptr());
+      if constexpr (Ctx::kUseMxmma && Ctx::kUseUmma &&
+                    Ctx::kNumWriteSplits == 1 && EpilogueArithmetic::kCanWriteNative) {
+        epilogue.template call<true>(nullptr, &mma);
+      } else {
+        epilogue.call(mma.final_regs_c_as_ptr());
+      }
       if constexpr (TuningConfig::kUseTmaC) tma_wait_store_group<0, true>();
       if constexpr (kUseTwoStageReduceBarrier) consumer.arrive(kNumStages + 1);
       if constexpr (!kReduceOverlapLastStageOnly) consumer.arrive(kNumStages);

--- a/humming/include/humming/mma/mxumma.cuh
+++ b/humming/include/humming/mma/mxumma.cuh
@@ -107,6 +107,27 @@ struct MXUMMA : MXMMA<Ctx, ArithClass> {
     tcgen05_fence_after_thread_sync();
   }
 
+  template <class OutputArithmetic>
+  CUDA_INLINE void write_native_output(OutputArithmetic &arith) {
+    static_assert(!Ctx::kUseStreamK && BlockShape::K == Ctx::WarpShape::K);
+    static_assert(Ctx::kNumWriteSplits == 1);
+    __nv_bfloat16 *out = reinterpret_cast<__nv_bfloat16 *>(ctx.smem.reduce);
+    const uint32_t swizzle = offsetof(SharedStorage, reduce) / 128 % 8;
+    const uint32_t n = threadIdx.x;
+    PRAGMA_UNROLL
+    for (uint32_t m = 0; m < BlockShape::M; m += 8) {
+      uint32_t values[8];
+      tcgen05_ld_32x32b_x8(ctx.smem.umma_tmem_col + kAccumulatorColumn + m, values);
+      tcgen05_wait_ld();
+      PRAGMA_UNROLL
+      for (uint32_t i = 0; i < 8; i++) {
+        uint32_t row = (n / 64) * BlockShape::M + m + i;
+        uint32_t col = ((n % 64 / 8) ^ ((m + i + swizzle) % 8)) * 8 + n % 8;
+        out[row * 64 + col] = arith.apply_native_output(__uint_as_float(values[i]));
+      }
+    }
+  }
+
   template <class T = uint32_t>
   CUDA_INLINE T *final_regs_c_as_ptr() {
     uint32_t lane = ctx.lane_id();

--- a/tests/kernels/humming/test_umma.py
+++ b/tests/kernels/humming/test_umma.py
@@ -532,3 +532,58 @@ def test_mxumma_public_input_scales(prequantized, shape_k, shape_m, gemm_type, m
         config, inputs=inputs, input_scale=scale_bytes, **runner.kernel_tensors, **kwargs
     )
     torch.testing.assert_close(output.float(), reference, atol=0.05, rtol=0.01)
+
+
+@pytest.mark.parametrize(
+    "gemm_type",
+    (GemmType.INDEXED, GemmType.GROUPED_CONTIGUOUS, GemmType.GROUPED_MASKED),
+)
+@pytest.mark.parametrize("epilogue", ("none", "bias", "tensor-bias", "channel-bias"))
+@pytest.mark.parametrize("block_m,shape_k", ((64, 640), (128, 896)))
+def test_mxumma_native_output_persistent_stage_reuse(
+    gemm_type, block_m, shape_k, epilogue, monkeypatch
+):
+    """Direct output staging survives odd input rings and persistent tile reuse."""
+
+    def native_tuning(layer_config, shape_m, gemm_type, **kwargs):
+        return get_heuristics_config(
+            layer_config, shape_m=shape_m, gemm_type=gemm_type
+        ) | {
+            "block_shape": (block_m, 128, 128),
+            "warp_shape": (block_m, 32, 128),
+            "num_stages": 3,
+            "num_sms": 2,
+        }
+
+    monkeypatch.setattr("humming.testing.tuning.get_heuristics_config", native_tuning)
+    case = KernelTestCase(
+        name="native-output-stage-reuse",
+        layer_config=LayerConfig(
+            shape_n=256,
+            shape_k=shape_k,
+            num_experts=4,
+            a_dtype="float8e4m3",
+            b_dtype="float4e2m1",
+            c_dtype="bfloat16",
+            as_dtype="float8e8m0",
+            bs_dtype="float8e8m0",
+            input_scale_group_size=32,
+            weight_scale_group_size=32,
+            mma_type=MmaType.MXMMA,
+            has_bias=epilogue != "none",
+            weight_scale_2_type=epilogue.split("-")[0] if "-" in epilogue else None,
+        ),
+        compute_config=ComputeConfig(gemm_type=gemm_type),
+        seed=2026,
+    )
+    runner = KernelTestRunner(case)
+    kernels = runner.prepare_kernels((17, 257))
+    assert all(
+        HummingKernel._id2kernel[int(kernel[0][2])].use_mxumma
+        for variants in kernels.values()
+        for kernel in variants
+    )
+    for result in runner.run((17, 257)):
+        torch.testing.assert_close(
+            result.outputs, result.outputs_ref, rtol=case.rtol, atol=case.atol
+        )


### PR DESCRIPTION
Stacked on [Humming #73](https://github.com/inclusionAI/humming/pull/73). This draft contains only the native MXUMMA output-staging change: 5 files, +127/-3, including 55 lines in the existing kernel tests.

Read accumulators in their native TMEM coordinates, apply the existing BF16 output arithmetic and write the existing swizzled shared-memory output slab. This removes the conversion to the legacy FP32 register layout. Bias and secondary scale rounding are preserved; unsupported arithmetic/output-split configurations use the existing path. Storage sizes, the MMA main loop, routing, output writers and synchronization protocol stay the same.

Validation on B300/SM103 with CUDA 13.0:

```sh
CUDA_VISIBLE_DEVICES=0 PYTHONPATH="$PWD" /home/mgoin/code/vllm/.venv/bin/python -m pytest tests/kernels/humming/test_umma.py -k 'mxumma or pipeline_stage_reuse' -q
```

The recorded final selection passed 68 native/public/pipeline regressions. Additional checks compared 24 arithmetic cases bitwise against the original cubins, exercised changing-input CUDA graphs, and passed tensor-operation memcheck, racecheck and synccheck with zero reported errors/hazards. Ruff and `git diff --check` passed. The publication tree is identical to validated combined Humming `517cca0`; only commit ordering was changed to make this a separate review.

Same-input projection measurements use FlashInfer CUPTI, CUDA graphs, cold L2 and three alternating rounds; quantization, packing and communication are excluded. Both implementations pass a dequantized FP32 reference with TF32 disabled (`atol=0.002`, `rtol=0.008`) and match each other bitwise. At fixed BM128/BN128/BK128, four stages and two requested CTAs/SM:

| Local projection | Rows/expert | Original us | Direct output us |
|---|---:|---:|---:|
| Flash down | 256 | 98.24 | 92.00 |
| Flash down | 512 | 179.88 | 166.98 |
| Pro down | 512 | 596.93 | 571.24 |

Explicit BM64, 16-row Flash guards improved about 1–1.4%; long-K Pro gate was near-neutral/noisy. The no-bias BM128 example removes 320 shuffle sites and lowers registers from 115 to 75, while increasing shared-store work. Actual padded GPT-OSS gate kernels retain their register spills. These measurements do not establish native-backend parity or distributed EP performance.

Real GPT-OSS TP2 and full GSM8K were also checked with this change plus the vLLM activation-fusion companion; combined results belong to that companion description and are not attributed solely to this patch. Current open Humming tuning PRs do not duplicate this epilogue change.

AI assistance: implementation, independent arithmetic/lifetime review and validation used OpenAI Codex, including GPT-6 Astra. Retarget to main after the A8 support dependency merges.
