### PR TITLE
feat(sm100): add FP4 activation support

### DIFF
--- a/humming/config/config.py
+++ b/humming/config/config.py
@@ -100,8 +100,15 @@ class LayerConfig(BaseHummingConfig):
     @property
     def mxmma_supported(self):
         assert self.sm_version is not None
-        if self.sm_version // 10 != 12:
+        if self.sm_version // 10 not in (10, 12):
             return False
+        if self.sm_version // 10 == 10:
+            if self.a_dtype != dtypes.float4e2m1:
+                return False
+            from humming.jit.runtime import KernelRuntime
+
+            if _cuda_compiler_version(KernelRuntime._get_compiler()) < (12, 9):
+                return False
         if not (self.is_group_weight_scale or self.is_channel_weight_scale):
             return False
         if (
@@ -303,6 +310,10 @@ class LayerConfig(BaseHummingConfig):
         assert self.mma_type is not None
         value = self.mma_type.value.lower()
         return ["mma", "wgmma", "umma", "mxmma"].index(value)
+
+    @property
+    def use_mxumma(self) -> bool:
+        return self.mma_type == MmaType.MXMMA and self.sm_version // 10 == 10
 
     @property
     def mxmma_native_mixed(self) -> bool:

--- a/humming/forward.py
+++ b/humming/forward.py
@@ -26,6 +26,14 @@ def _prepare_input_scale(config: LayerConfig, input_scale: torch.Tensor) -> torc
     mx_scale_dtype = str(config.as_dtype) in ("float8e4m3", "float8e8m0")
     grouped_mxmma = config.mma_type == MmaType.MXMMA and config.input_scale_group_size > 0
     if mx_scale_dtype and grouped_mxmma and input_scale.dtype != torch.int32:
+        if config.use_mxumma and input_scale.ndim == 2:
+            group_size = config.input_scale_group_size
+            logical_groups = (config.shape_k - config.pad_shape_k) // group_size
+            packed_groups = (config.shape_k // group_size + 3) // 4 * 4
+            if input_scale.size(-1) == logical_groups and logical_groups < packed_groups:
+                input_scale = torch.nn.functional.pad(
+                    input_scale.view(torch.uint8), (0, packed_groups - logical_groups)
+                )
         packed_scale = input_scale.view(torch.int32)
         if input_scale.ndim == 3:
             packed_scale = packed_scale.reshape(input_scale.size(0), input_scale.size(1))
@@ -115,12 +123,16 @@ def may_quant_input(
         return inputs, None
     if input_scale is not None:
         config.check_device(inputs.device)
-        return inputs, input_scale
+        return inputs, _prepare_input_scale(config, input_scale)
     outputs, group_scales, token_scales = may_process_input(
         config,
         inputs=inputs,
         outputs=quanted_input,
-        m_major_scale=(config.mma_type == MmaType.MXMMA and config.input_scale_group_size > 0),
+        m_major_scale=(
+            config.mma_type == MmaType.MXMMA
+            and config.input_scale_group_size > 0
+            and not config.use_mxumma
+        ),
         use_pdl=use_pdl,
     )
     if token_scales is not None:
@@ -171,8 +183,8 @@ def humming_forward(
         if token_scales is not None:
             token_scales = token_scales.unsqueeze(-1)
         input_scale = group_scales if group_scales is not None else token_scales
-        if input_scale is not None:
-            input_scale = _prepare_input_scale(config, input_scale)
+    if input_scale is not None:
+        input_scale = _prepare_input_scale(config, input_scale)
 
     if isinstance(compute_config, dict):
         compute_config = json.dumps(compute_config)

--- a/humming/include/humming/memory/g2s_loader/loader_as.cuh
+++ b/humming/include/humming/memory/g2s_loader/loader_as.cuh
@@ -35,6 +35,7 @@ private:
   static constexpr uint32_t kProblemNumGroups = CEIL_DIV(ProblemShape::K - PadShape::K, kGroupSize);
   static constexpr uint32_t kNumGroups = CEIL_DIV(BlockShape::K, kGroupSize);
   static constexpr uint32_t kMxScaleVec = kPartMmaShapeK / kGroupSize;
+  static constexpr uint32_t kMxGmemStride = ProblemShape::K / kPartMmaShapeK * kMxScaleVec / 4;
   static constexpr uint32_t kLoadsPerGroup =
       kUseMxScale ? MAX(1u, 4 / kNumGroups) : CEIL_DIV(kGroupSize, BlockShape::K);
   static constexpr uint32_t kRowLoadIters = CEIL_DIV(BlockShape::M, kNumLoadThreads);
@@ -88,10 +89,22 @@ public:
     const uint32_t *gmem_ptr_load = reinterpret_cast<const uint32_t *>(gmem_ptr);
 
     constexpr uint32_t kNumRows = CEIL_DIV(BlockShape::K / kPartMmaShapeK * kMxScaleVec, 4);
-    constexpr uint32_t kMxGmemStride = ProblemShape::K / kPartMmaShapeK * kMxScaleVec / 4;
     constexpr uint32_t kNumInts = BlockShape::M * kNumRows;
 
-    if constexpr (kNumInts <= kNumLoadThreads) {
+    if constexpr (kIsIndexedGemm) {
+      PRAGMA_UNROLL
+      for (uint32_t i = 0; i < kRowLoadIters; i++) {
+        uint32_t row = i * kNumLoadThreads + thread_id;
+        uint32_t input_row = load_row_index[i];
+        PRAGMA_UNROLL
+        for (uint32_t group = 0; group < kNumRows; group++) {
+          legacy_load_pred<kUseCpAsync>(
+              gmem_ptr_load + input_row * kMxGmemStride + group,
+              smem_ptr_load + group * BlockShape::M + row,
+              row < BlockShape::M && input_row < shape_m);
+        }
+      }
+    } else if constexpr (kNumInts <= kNumLoadThreads) {
       uint32_t smem_offset = thread_id;
       uint32_t smem_row = smem_offset / BlockShape::M;
       uint32_t smem_col = smem_offset % BlockShape::M;
@@ -252,7 +265,7 @@ public:
           if constexpr (kMMajorInputScale)
             gmem_ptr = gmem_ptr_raw + ((col_offset / 4) * total_shape_m + MIN(row_offset, total_shape_m));
           else
-            gmem_ptr = gmem_ptr_raw + (row_offset * (kProblemNumGroups / 4) + col_offset / 4);
+            gmem_ptr = gmem_ptr_raw + (row_offset * kMxGmemStride + col_offset / 4);
         }
       } else if constexpr (kUseTma) {
         // tma loads via tensor map; gmem_ptr unused
@@ -262,7 +275,7 @@ public:
         gmem_ptr = gmem_ptr_raw + ((row_offset * kProblemNumGroups) + col_offset);
       }
     } else {
-      gmem_ptr = gmem_ptr_raw + col_offset;
+      gmem_ptr = gmem_ptr_raw + (kUseMxScale ? col_offset / 4 : col_offset);
 
       PRAGMA_UNROLL
       for (uint32_t i = 0; i < kRowLoadIters; i++) {

--- a/humming/include/humming/mma/all.cuh
+++ b/humming/include/humming/mma/all.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <humming/mma/mxmma.cuh>
+#include <humming/mma/mxumma.cuh>
 #include <humming/mma/wgmma.cuh>
 #include <humming/mma/wmma.cuh>
 #include <humming/mma/umma.cuh>
@@ -21,7 +22,7 @@ struct MmaSelector<MmaType::WGMMA, Ctx, ArithClass> {
 
 template <class Ctx, class ArithClass>
 struct MmaSelector<MmaType::MXMMA, Ctx, ArithClass> {
-  using Type = MXMMA<Ctx, ArithClass>;
+  using Type = typename std::conditional<Ctx::kUseUmma, MXUMMA<Ctx, ArithClass>, MXMMA<Ctx, ArithClass>>::type;
 };
 
 template <class Ctx, class ArithClass>

--- a/humming/include/humming/mma/mxumma.cuh
+++ b/humming/include/humming/mma/mxumma.cuh
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <humming/mma/mxmma.cuh>
+#include <humming/mma/umma.cuh>
+
+
+CUDA_INLINE void mxumma_store_scales(uint32_t address, const uint32_t *values) {
+  asm volatile("tcgen05.st.sync.aligned.32x32b.x4.b32 [%0], {%1, %2, %3, %4};"
+               :: "r"(address), "r"(values[0]), "r"(values[1]),
+                  "r"(values[2]), "r"(values[3]) : "memory");
+}
+
+
+template <uint32_t kN, uint32_t kScaleVec, bool kE4M3>
+CUDA_INLINE void mxumma_mma(uint32_t d, uint32_t a, uint64_t b,
+                            uint32_t sfa, uint32_t sfb, uint32_t scale_id,
+                            bool accumulate) {
+  constexpr uint32_t descriptor = (1u << 7) | (1u << 10)
+      | ((kN / 8) << 17) | (uint32_t(!kE4M3) << 23) | (8u << 24);
+  uint32_t idesc = descriptor | (scale_id << 29) | (scale_id << 4);
+  if constexpr (kScaleVec == 2) {
+    asm volatile(
+        "{ .reg .pred p; setp.ne.b32 p, %6, 0;\n"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 "
+        "[%0], [%1], %2, %3, [%4], [%5], p; }"
+        :: "r"(d), "r"(a), "l"(b), "r"(idesc), "r"(sfa), "r"(sfb),
+           "r"(uint32_t(accumulate)) : "memory");
+  } else {
+    asm volatile(
+        "{ .reg .pred p; setp.ne.b32 p, %6, 0;\n"
+        "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 "
+        "[%0], [%1], %2, %3, [%4], [%5], p; }"
+        :: "r"(d), "r"(a), "l"(b), "r"(idesc), "r"(sfa), "r"(sfb),
+           "r"(uint32_t(accumulate)) : "memory");
+  }
+}
+
+
+template <class Ctx, class ArithClass>
+struct MXUMMA : MXMMA<Ctx, ArithClass> {
+  using Base = MXMMA<Ctx, ArithClass>;
+  using BlockShape = typename Ctx::BlockShape;
+  using SharedStorage = typename Ctx::SharedStorage;
+  using MmaOpClass = typename Ctx::MmaOpClass;
+  using Base::ctx;
+  static constexpr uint32_t kScaleVec = MmaOpClass::kScaleVec;
+  static constexpr uint32_t kScaleWords = Ctx::kWarpIters * kScaleVec / 4;
+  static constexpr uint32_t kOperandColumns = Ctx::kWarpIters * 8;
+  static constexpr uint32_t kScaleAColumn = 2 * kOperandColumns;
+  static constexpr uint32_t kScaleBColumn = kScaleAColumn + kScaleWords * 4;
+  static constexpr uint32_t kAccumulatorColumn = kScaleBColumn + kScaleWords * 4;
+  static constexpr uint32_t kTmemColumns =
+      kAccumulatorColumn + BlockShape::M <= 128 ? 128 : 256;
+
+  static_assert(std::is_same<typename Ctx::ElementA, Float4E2M1>::value);
+  static_assert(BlockShape::N == 128 && (BlockShape::K == 128 || BlockShape::K == 256));
+  static_assert(Ctx::kNumMathThreads == 128);
+
+  CUDA_INLINE MXUMMA(Ctx &ctx, ArithClass &arith) : Base(ctx, arith) {}
+
+  CUDA_INLINE static void init(SharedStorage &smem) {
+    if (threadIdx.x < 32) tcgen05_alloc<kTmemColumns>(cast_smem_ptr_to_uint(&smem.umma_tmem_col));
+    if (threadIdx.x == 0) __mbarrier_init(&smem.umma_mbar, 1);
+    __syncthreads();
+  }
+
+  CUDA_INLINE static void dealloc(SharedStorage &smem) {
+    if (threadIdx.x < 32) tcgen05_dealloc<kTmemColumns>(smem.umma_tmem_col);
+  }
+
+  CUDA_INLINE void zero_accum() {
+    first_issue = true;
+    operand_buffer = 0;
+  }
+
+  CUDA_INLINE void transform_b(uint32_t buffer_id, uint32_t iter_id) {
+    Base::transform_b(buffer_id, iter_id);
+    const uint32_t *values = reinterpret_cast<const uint32_t *>(this->regs_b[buffer_id]);
+    uint32_t address = ctx.smem.umma_tmem_col + operand_buffer * kOperandColumns + iter_id * 8;
+    tcgen05_st_16x128b_x2(address, values);
+    tcgen05_st_16x128b_x2(address | (16u << 16), values + 4);
+    if (iter_id == Ctx::kWarpIters - 1) {
+      tcgen05_wait_st();
+      tcgen05_fence_before_thread_sync();
+    }
+  }
+
+  CUDA_INLINE void run(uint32_t stage_id, uint32_t iter_id) {
+    if (iter_id != Ctx::kWarpIters - 1) return;
+    uint32_t base = ctx.smem.umma_tmem_col;
+    // Replicate each scale matrix across all four 32-lane TMEM partitions.
+    PRAGMA_UNROLL
+    for (uint32_t word = 0; word < kScaleWords; word++) {
+      uint32_t weights[4], inputs[4];
+      PRAGMA_UNROLL
+      for (uint32_t i = 0; i < 4; i++) {
+        uint32_t row = ctx.lane_id() + i * 32;
+        weights[i] = Base::kSFOneWord;
+        inputs[i] = Base::kSFOneWord;
+        if constexpr (Base::kIsGroupOrBlockWeightScale)
+          weights[i] = reinterpret_cast<const uint32_t *>(ctx.smem.stages[stage_id].bs)[word * BlockShape::N + row];
+        if constexpr (Base::kIsGroupInputScale) {
+          if (row < BlockShape::M)
+            inputs[i] = reinterpret_cast<const uint32_t *>(ctx.smem.stages[stage_id].as)[word * BlockShape::M + row];
+        }
+      }
+      mxumma_store_scales(base + kScaleAColumn + word * 4, weights);
+      mxumma_store_scales(base + kScaleBColumn + word * 4, inputs);
+    }
+    tcgen05_wait_st();
+    tcgen05_fence_before_thread_sync();
+    if constexpr (!Ctx::kUseTmaA) {
+      if (threadIdx.x == 0) tma_fence_async_shared();
+    }
+    ctx.sync_math_threads();
+    tcgen05_fence_after_thread_sync();
+    if (threadIdx.x == 0) {
+      PRAGMA_UNROLL
+      for (uint32_t k = 0; k < Ctx::kWarpIters; k++) {
+        const void *ptr = &ctx.smem.stages[stage_id].a[k * 2];
+        uint64_t descriptor = ((uint64_t(cast_smem_ptr_to_uint(ptr)) >> 4) & 0x3fff)
+            | (uint64_t(1) << 16) | (uint64_t(BlockShape::K / 4) << 32)
+            | (uint64_t(1) << 46) | (uint64_t(BlockShape::K == 128 ? 4 : 2) << 61);
+        uint32_t word = (k * kScaleVec / 4) * 4;
+        mxumma_mma<BlockShape::M, kScaleVec, MmaOpClass::kSFIsE4M3>(
+            base + kAccumulatorColumn,
+            base + operand_buffer * kOperandColumns + k * 8, descriptor,
+            base + kScaleAColumn + word, base + kScaleBColumn + word,
+            (k * kScaleVec) % 4, !first_issue || k != 0);
+      }
+      tcgen05_commit(cast_smem_ptr_to_uint(&ctx.smem.umma_mbar));
+    }
+    first_issue = false;
+    operand_buffer ^= 1;
+  }
+
+  CUDA_INLINE void wait_stage() {
+    mbarrier_wait(&ctx.smem.umma_mbar, phase);
+    phase ^= 1;
+    tcgen05_fence_after_thread_sync();
+  }
+
+  template <class T = uint32_t>
+  CUDA_INLINE T *final_regs_c_as_ptr() {
+    uint32_t lane = ctx.lane_id();
+    uint32_t source_lane = (lane & 24u) | ((lane & 3u) << 1) | ((lane >> 2) & 1u);
+    PRAGMA_UNROLL
+    for (uint32_t m = 0; m < BlockShape::M / 8; m++) {
+      uint32_t values[8];
+      tcgen05_ld_32x32b_x8(ctx.smem.umma_tmem_col + kAccumulatorColumn + m * 8, values);
+      tcgen05_wait_ld();
+      PRAGMA_UNROLL
+      for (uint32_t i = 0; i < 8; i++) values[i] = __shfl_sync(0xffffffff, values[i], source_lane);
+      umma_transpose_bit<1, 4>(values);
+      umma_transpose_bit<2, 8>(values);
+      umma_transpose_bit<4, 16>(values);
+      PRAGMA_UNROLL
+      for (uint32_t n = 0; n < 4; n++) {
+        this->regs_c[m / 2][n][m % 2 * 2] = __uint_as_float(values[n * 2]);
+        this->regs_c[m / 2][n][m % 2 * 2 + 1] = __uint_as_float(values[n * 2 + 1]);
+      }
+    }
+    return Base::template regs_c_as_ptr<T>();
+  }
+
+private:
+  bool first_issue = true;
+  uint32_t operand_buffer = 0;
+  uint32_t phase = 0;
+};

--- a/humming/include/humming/utils/context.cuh
+++ b/humming/include/humming/utils/context.cuh
@@ -53,7 +53,7 @@ struct KernelContext : LayerConfig_, ComputeConfig_, TuningConfig_ {
   static constexpr bool kIsGroupedGemm = kIsGroupedContiguousGemm || kIsGroupedMaskedGemm;
 
   static constexpr bool kUseWmma = LayerConfig::kMmaType == MmaType::MMA;
-  static constexpr bool kUseUmma = LayerConfig::kMmaType == MmaType::UMMA;
+  static constexpr bool kUseUmma = LayerConfig::kMmaType == MmaType::UMMA || (LayerConfig::kMmaType == MmaType::MXMMA && LayerConfig::kSmVersion / 10 == 10);
   static constexpr bool kUseWgmma = LayerConfig::kMmaType == MmaType::WGMMA;
   static constexpr bool kUseMxmma = LayerConfig::kMmaType == MmaType::MXMMA;
 

--- a/humming/include/humming/utils/storage.cuh
+++ b/humming/include/humming/utils/storage.cuh
@@ -2,7 +2,7 @@
 
 #include <humming/utils/base.cuh>
 
-#if HUMMING_MMA_TYPE_ID == 2
+#if HUMMING_MMA_TYPE_ID == 2 || (HUMMING_MMA_TYPE_ID == 3 && HUMMING_SM_VERSION / 10 == 10)
 #define IF_USE_UMMA(x) x
 #else
 #define IF_USE_UMMA(x)

--- a/humming/kernel/humming.py
+++ b/humming/kernel/humming.py
@@ -115,7 +115,7 @@ class HummingKernel(KernelRuntime, LayerConfig, ComputeConfig, TuningConfig):
 
     def init_sm_version(self):
         super().init_sm_version()
-        if self.mma_type == MmaType.UMMA:
+        if self.mma_type == MmaType.UMMA or self.use_mxumma:
             assert self.sm_version // 10 == 10, "UMMA requires SM100 family"
             assert _cuda_compiler_version(self._get_compiler()) >= (12, 9), (
                 "UMMA sm_100f requires CUDA 12.9 or newer"
@@ -370,7 +370,7 @@ class HummingKernel(KernelRuntime, LayerConfig, ComputeConfig, TuningConfig):
             dtypes.int4: 80,
             dtypes.int8: 75,
             dtypes.float4e0m3: 120,
-            dtypes.float4e2m1: 120,
+            dtypes.float4e2m1: 100 if self.use_mxumma else 120,
             dtypes.float8e3m4: 120,
             dtypes.float8e4m3: 89,
             dtypes.float8e5m2: 89,
@@ -419,6 +419,24 @@ class HummingKernel(KernelRuntime, LayerConfig, ComputeConfig, TuningConfig):
             assert not self.use_f16_accum
             assert not self.use_pdl
             assert not self.reduce_overlap_last_stage_only
+            assert self.multi_cast_size_a == self.multi_cast_size_b == 1
+        if self.use_mxumma:
+            assert self.mxmma_supported
+            if self.input_scale_group_size > 0:
+                expected_scale = (
+                    self.bs_dtype if self.is_group_weight_scale
+                    else dtypes.float8e4m3 if self.input_scale_group_size == 16
+                    else dtypes.float8e8m0
+                )
+                assert self.as_dtype == expected_scale
+            assert self.block_shape[0] in (64, 128)
+            assert self.block_shape[1] == 128 and self.block_shape[2] in (128, 256)
+            assert tuple(self.warp_shape) == (
+                self.block_shape[0], 32, self.block_shape[2]
+            )
+            assert self.use_warp_spec and self.num_stages >= 3
+            assert not self.use_pdl and not self.reduce_overlap_last_stage_only
+            assert not self.use_stream_k
             assert self.multi_cast_size_a == self.multi_cast_size_b == 1
         assert not (self.mma_type == MmaType.MXMMA and self.use_f16_accum), (
             "MXMMA does not support FP16 accumulation"

--- a/humming/tune/sm100.py
+++ b/humming/tune/sm100.py
@@ -11,6 +11,7 @@ from humming.utils.smem import estimate_smem_size_layer
 class Sm100Heuristics(Sm80Heuristics):
     max_smem_size: int = 227 * 1024
     sm_version: int = 100
+    b4_allowed_dtypes: list[dtypes.DataType] = [dtypes.int4, dtypes.float4e2m1]
     b8_allowed_dtypes: list[dtypes.DataType] = [dtypes.int8, dtypes.float8e4m3, dtypes.float8e5m2]
 
     @classmethod
@@ -22,6 +23,34 @@ class Sm100Heuristics(Sm80Heuristics):
         use_batch_invariant: bool = False,
         gemm_type: GemmType = GemmType.DENSE,
     ):
+        if layer_config.use_mxumma:
+            indexed = gemm_type == GemmType.INDEXED
+            block_m = 64 if shape_m < 128 * (layer_config.num_experts or 1) else 128
+            block_k = 256 if layer_config.shape_k % 256 == 0 else 128
+            num_ctas = 1
+            tiles = math.ceil(shape_m / block_m) * (layer_config.shape_n // 128)
+            if tiles >= 2 * current_device.sm_count:
+                smem_size = estimate_smem_size_layer(
+                    layer_config, (block_m, 128, 128), gemm_type, 4,
+                    warp_shape=(block_m, 32, 128),
+                    use_mbarrier=True, use_warp_spec=True,
+                )
+                if 2 * smem_size <= cls.max_smem_size:
+                    block_k, num_ctas = 128, 2
+            return {
+                "mma_type": MmaType.MXMMA.value,
+                "block_shape": (block_m, 128, block_k),
+                "warp_shape": (block_m, 32, block_k),
+                "num_stages": 4,
+                "num_ctas_per_sm": num_ctas,
+                "use_warp_spec": True,
+                "use_tma": True,
+                "use_tma_a": not indexed,
+                "use_tma_c": not indexed,
+                "use_stream_k": False,
+                "use_pdl": False,
+                "raster_group_m": 1,
+            }
         if layer_config.mma_type != MmaType.UMMA:
             return super().get_config(
                 layer_config, shape_m, use_f16_accum, use_batch_invariant, gemm_type

--- a/humming/utils/smem.py
+++ b/humming/utils/smem.py
@@ -162,7 +162,7 @@ def estimate_smem_size_layer(
             num_math_mbarriers += 1
         add(num_math_mbarriers * 8, 8)  # math_mbar
 
-    if layer_config.mma_type == MmaType.UMMA:
+    if layer_config.mma_type == MmaType.UMMA or layer_config.use_mxumma:
         add(4, 4)  # TMEM allocation
         add(8, 8)  # MMA completion barrier
 

--- a/tests/kernels/humming/test_mxmma.py
+++ b/tests/kernels/humming/test_mxmma.py
@@ -261,3 +261,298 @@ def test_mxmma_case_coverage():
         dtypes.float8e4m3,
         dtypes.float8e5m2,
     }
+
+
+def _require_sm100_mxmma():
+    from humming.config.config import _cuda_compiler_version
+    from humming.jit.runtime import KernelRuntime
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 10:
+        pytest.skip("Native block-scaled UMMA requires SM100 family")
+    if _cuda_compiler_version(KernelRuntime._get_compiler()) < (12, 9):
+        pytest.skip("Native block-scaled UMMA requires CUDA 12.9 or newer")
+
+
+@pytest.mark.parametrize("gemm_type", list(GemmType))
+@pytest.mark.parametrize(
+    "group_size,scale_dtype",
+    ((32, dtypes.float8e8m0), (16, dtypes.float8e4m3)),
+    ids=("mxfp4", "nvfp4"),
+)
+def test_sm100_mxmma_formats_and_moe(gemm_type, group_size, scale_dtype):
+    """Native FP4 preserves group scales through routing and stage reuse."""
+    import dataclasses
+
+    from humming.kernel.humming import HummingKernel
+
+    _require_sm100_mxmma()
+    case = _case(
+        "sm100-fp4",
+        a_dtype=dtypes.float4e2m1,
+        b_dtype=dtypes.float4e2m1,
+        bs_dtype=scale_dtype,
+        group_size=group_size,
+        gemm_type=gemm_type,
+    )
+    case = dataclasses.replace(
+        case,
+        layer_config=dataclasses.replace(
+            case.layer_config,
+            shape_n=256,
+            shape_k=768,
+            num_experts=0 if gemm_type == GemmType.DENSE else 4,
+        ),
+    )
+    runner = KernelTestRunner(case)
+    shape_ms = (1, 17, 65, 257)
+    kernels = runner.prepare_kernels(shape_ms)
+    assert all(
+        HummingKernel._id2kernel[int(kernel[0][2])].use_mxumma
+        for variants in kernels.values()
+        for kernel in variants
+    )
+    for result in runner.run(shape_ms):
+        torch.testing.assert_close(
+            result.outputs, result.outputs_ref, rtol=case.rtol, atol=case.atol
+        )
+
+
+@pytest.mark.parametrize(
+    "b_dtype,zero_point,input_group,weight_group,scale_dtype,secondary_scale",
+    (
+        (dtypes.uint1, False, 32, 32, dtypes.float8e8m0, None),
+        (dtypes.uint2, True, 16, 16, dtypes.float8e4m3, None),
+        (dtypes.uint3, False, 32, 32, dtypes.float8e8m0, None),
+        (dtypes.float4e2m1, False, 0, 32, dtypes.float8e8m0, None),
+        (dtypes.float4e2m1, False, 32, 0, dtypes.bfloat16, None),
+        (dtypes.float4e2m1, False, 16, 16, dtypes.float8e4m3, "tensor"),
+    ),
+)
+def test_sm100_mxmma_weight_contract(
+    b_dtype, zero_point, input_group, weight_group, scale_dtype, secondary_scale
+):
+    """Register dequantization and channel scales retain their FP4 contract."""
+    import dataclasses
+
+    _require_sm100_mxmma()
+    case = _case(
+        "sm100-weight-contract",
+        a_dtype=dtypes.float4e2m1,
+        b_dtype=b_dtype,
+        bs_dtype=scale_dtype,
+        group_size=32,
+        input_group_size=input_group,
+        weight_group_size=weight_group,
+        has_zero_point=zero_point,
+        gemm_type=GemmType.INDEXED,
+    )
+    case = dataclasses.replace(
+        case,
+        layer_config=dataclasses.replace(
+            case.layer_config,
+            shape_n=256,
+            shape_k=256,
+            num_experts=4,
+            weight_scale_2_type=secondary_scale,
+        ),
+    )
+    for result in KernelTestRunner(case).run((17, 129)):
+        torch.testing.assert_close(
+            result.outputs, result.outputs_ref, rtol=case.rtol, atol=case.atol
+        )
+
+
+@pytest.mark.parametrize("gemm_type", (GemmType.DENSE, GemmType.INDEXED))
+@pytest.mark.parametrize("shape_k", (256, 2880))
+def test_sm100_mxmma_public_layer_reuses_packed_weights(gemm_type, shape_k):
+    """Packed scale strides survive K padding and prefill followed by decode."""
+    from humming import ops
+    from humming.forward import may_quant_input
+    from humming.kernel.humming import HummingKernel
+    from humming.layer import HummingLayer
+    from humming.schema import HummingWeightSchema
+    from humming.testing.data import generate_moe_tensors, generate_random_tensor
+    from humming.tune import get_heuristics_config
+
+    _require_sm100_mxmma()
+    torch.manual_seed(2026)
+    num_experts = 0 if gemm_type == GemmType.DENSE else 4
+    schema = HummingWeightSchema(
+        b_dtype="float4e2m1",
+        bs_dtype="float8e8m0",
+        weight_scale_group_size=32,
+    )
+    weight_shape = (4, 256, shape_k) if num_experts else (256, shape_k)
+    weight = generate_random_tensor(weight_shape, torch.bfloat16, device="cuda")
+    tensors = schema.quant_tensor(weight, schema, torch.bfloat16)
+    weight_ref = schema.dequant_tensors(tensors)
+    layer = HummingLayer(
+        shape_n=256,
+        shape_k=shape_k,
+        pad_k_to_multiple=128,
+        num_experts=num_experts,
+        weight_config=schema,
+        input_config={"dtype": "float4e2m1", "group_size": 32},
+        torch_dtype=torch.bfloat16,
+    ).cuda()
+    layer.load_state_dict(tensors, strict=False)
+    layer.transform()
+    packed = {
+        name: (value.data_ptr(), value.detach().view(torch.uint8).clone())
+        for name, value in layer.named_parameters()
+    }
+    for shape_m in (17, 257, 1):
+        inputs = generate_random_tensor((shape_m, shape_k), torch.bfloat16, device="cuda")
+        quant, scales, _ = ops.process_input(
+            inputs,
+            quant_mode="dynamic_group",
+            quant_dtype="float4e2m1",
+            quant_group_size=32,
+            group_scale_dtype="float8e8m0",
+        )
+        codes = ops.unpack_weight(quant.view(torch.int32), 4)
+        inputs_ref = ops.dequant_weight(codes, 2, 1, True).float()
+        inputs_ref *= scales.float().repeat_interleave(32, 1)
+        kwargs = {}
+        dispatch_m = shape_m
+        if num_experts:
+            ids = torch.tensor([0, 2], device="cuda", dtype=torch.int32)
+            ids = ids.expand(shape_m, -1).contiguous()
+            tuning = get_heuristics_config(
+                layer.humming_config,
+                shape_m * 2,
+                gemm_type=gemm_type,
+            )
+            _, _, sorted_ids, expert_ids, padded = generate_moe_tensors(
+                ids,
+                4,
+                gemm_type,
+                block_size_config=tuning["block_shape"][0],
+            )
+            kwargs = dict(
+                sorted_ids=sorted_ids,
+                expert_ids=expert_ids,
+                num_tokens_padded=padded,
+                top_k=2,
+            )
+            reference = torch.stack(
+                [inputs_ref @ weight_ref[e].T for e in (0, 2)],
+                dim=1,
+            ).flatten(0, 1)
+            dispatch_m *= 2
+        else:
+            reference = inputs_ref @ weight_ref.T
+        outputs = layer(inputs, **kwargs, compute_config={"gemm_type": gemm_type.value})
+        torch.testing.assert_close(
+            outputs,
+            reference.to(torch.bfloat16),
+            rtol=0.01,
+            atol=0.05,
+        )
+        prequant, prescale = may_quant_input(layer.humming_config, inputs)
+        prescale = prescale.view(torch.uint8)
+        preserved_input, normalized_scale = may_quant_input(
+            layer.humming_config,
+            prequant,
+            input_scale=prescale,
+        )
+        assert preserved_input.data_ptr() == prequant.data_ptr()
+        assert normalized_scale.data_ptr() == prescale.data_ptr()
+        assert normalized_scale.dtype == torch.int32
+        prequant_outputs = layer(
+            prequant,
+            input_scale=prescale,
+            **kwargs,
+            compute_config={"gemm_type": gemm_type.value},
+        )
+        torch.testing.assert_close(
+            prequant_outputs,
+            reference.to(torch.bfloat16),
+            rtol=0.01,
+            atol=0.05,
+        )
+        prepared = HummingKernel.prepare_kernels(
+            layer.humming_config.to_str(),
+            {"gemm_type": gemm_type.value},
+            None,
+        ).reshape(-1, 4)
+        selected = [row for row in prepared if int(row[0]) < dispatch_m <= int(row[1])]
+        assert len(selected) == 1
+        assert HummingKernel._id2kernel[int(selected[0][2])].use_mxumma
+    for name, value in layer.named_parameters():
+        pointer, original = packed[name]
+        assert pointer == value.data_ptr()
+        assert torch.equal(value.detach().view(torch.uint8), original)
+
+
+@pytest.mark.parametrize("block_k", (128, 256))
+@pytest.mark.parametrize(
+    "group_size,scale_dtype", ((32, "float8e8m0"), (16, "float8e4m3"))
+)
+def test_sm100_mxmma_minimum_pipeline_stages(
+    block_k, group_size, scale_dtype, monkeypatch
+):
+    """Retire operand and scale readers before wrapping the three-stage ring."""
+    _require_sm100_mxmma()
+    case = KernelTestCase(
+        name="sm100-stage-reuse",
+        layer_config=LayerConfig(
+            shape_n=256,
+            shape_k=block_k * 7,
+            num_experts=4,
+            a_dtype="float4e2m1",
+            b_dtype="float4e2m1",
+            c_dtype="bfloat16",
+            bs_dtype=scale_dtype,
+            input_scale_group_size=group_size,
+            weight_scale_group_size=group_size,
+        ),
+        compute_config=ComputeConfig(gemm_type=GemmType.GROUPED_MASKED),
+        top_k=2,
+        seed=2026,
+    )
+
+    def minimum_stages(layer_config, shape_m, gemm_type, **kwargs):
+        return {
+            "mma_type": "mxmma",
+            "block_shape": (64, 128, block_k),
+            "warp_shape": (64, 32, block_k),
+            "num_stages": 3,
+            "num_sms": 2,
+            "use_warp_spec": True,
+            "use_tma": True,
+            "use_stream_k": False,
+            "use_pdl": False,
+        }
+
+    monkeypatch.setattr("humming.testing.tuning.get_heuristics_config", minimum_stages)
+    for result in KernelTestRunner(case).run((17, 257)):
+        torch.testing.assert_close(
+            result.outputs,
+            result.outputs_ref,
+            rtol=case.rtol,
+            atol=case.atol,
+        )
+
+
+@pytest.mark.parametrize("compiler_version", ((12, 8), (12, 9)))
+def test_sm100_mxmma_compiler_eligibility(compiler_version, monkeypatch):
+    """Automatic FP4 dispatch requires the SM100-family compiler target."""
+    monkeypatch.setattr(
+        "humming.config.config._cuda_compiler_version",
+        lambda compiler: compiler_version,
+    )
+    config = LayerConfig(
+        sm_version=100,
+        shape_n=256,
+        shape_k=256,
+        a_dtype="float4e2m1",
+        b_dtype="float4e2m1",
+        c_dtype="bfloat16",
+        bs_dtype="float8e8m0",
+        input_scale_group_size=32,
+        weight_scale_group_size=32,
+    )
+    eligible = compiler_version >= (12, 9)
+    assert config.mxmma_supported == eligible
+    assert config.mma_type == (MmaType.MXMMA if eligible else MmaType.MMA)


### PR DESCRIPTION
Adds native SM100-family E2M1 FP4 activations for MXFP4 (group32/E8M0) and NVFP4 (group16/E4M3), with BF16 outputs. Dense, indexed, grouped-contiguous and grouped-masked GEMMs reuse existing weight packing and output handling. Coverage includes supported smaller integer weights dequantized to FP4, channel scales and NVFP4 secondary tensor scales.

Packed FP4 activations stay in shared memory; canonical weight fragments and scales are staged into TMEM for native block-scaled UMMA. The initial schedule uses BM64/BM128 and K128/K256 stages with bounded occupancy choices. Existing integer A4 and SM120 execution retain their paths. Explicit input scales and indexed gathers use the physical packed row stride, including logical K tails.

**Integration status:** this is the independently validated A4 branch against main. It overlaps [A8 #73](https://github.com/inclusionAI/humming/pull/73) in the new MXUMMA executor, eligibility and geometry selection. Keep it draft until those shared changes are reconciled; the two drafts cannot simply be merged as written. The [A8 native-output optimization #74](https://github.com/inclusionAI/humming/pull/74) has not been ported here. This preserves the tested A4 implementation for review without claiming a validated combined A4/A8 executor.

11 files, +564/-15, including 295 added lines in the existing MXMMA test module. The publication tree is identical to validated `83c616a`. Open Humming PRs were checked; current SM90 tuning work does not duplicate FP4 activation support on SM100.

Validation on B300/SM103, PyTorch 2.13.0+cu130, CUDA 13.0, generated sm_100f (CUDA >=12.9):

```sh
CUDA_VISIBLE_DEVICES=3 PYTHONPATH="$PWD" /home/mgoin/code/vllm/.venv/bin/python -m pytest tests/kernels/humming/test_mxmma.py -k sm100 -q
CUDA_VISIBLE_DEVICES=3 PYTHONPATH="$PWD" /home/mgoin/code/vllm/.venv/bin/python -m pytest tests/kernels/humming/test_umma.py -k pipeline_stage_reuse -q
CUDA_VISIBLE_DEVICES=2 PYTHONPATH="$PWD" /home/mgoin/code/vllm/.venv/bin/python -m pytest tests/kernels/humming/test_mxmma.py -k 'public_layer_reuses_packed_weights and 2880' -q -x
```

The support campaign passed 20 native cases across its recorded runs, public internal/prequantized input tests, compiler eligibility checks, five BF16 pipeline regressions and eight legacy integer-A4 comparisons. The later scale-stride correction passed 24 strict cases, six tensor-operation memchecks with zero errors and both retained K2880 public regressions. All active outputs are explicitly checked against independent references. Ruff and `git diff --check` passed.

Identical-input dense MXFP4 projection, N=K=4096, CUPTI/CUDA graphs/cold L2: at M512, Humming 1201 TFLOP/s versus DeepGEMM 1588; at M2048, 1786 versus 2818. Quantization, packing and routing are excluded. This is initial kernel/library support, not native performance parity; no A4 vLLM model evaluation or distributed EP measurement was performed.

AI assistance: implementation, review and validation used OpenAI Codex, including GPT-6 Astra.
